### PR TITLE
Promote stage into main

### DIFF
--- a/.github/scripts/run-dotnet-tests-with-coverage.ps1
+++ b/.github/scripts/run-dotnet-tests-with-coverage.ps1
@@ -1,0 +1,123 @@
+$ErrorActionPreference = "Stop"
+
+function Fail-Check {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    Write-Host "::error::$Message"
+
+    if ($env:GITHUB_STEP_SUMMARY) {
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Coverage Check Failure"
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ""
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $Message
+    }
+
+    throw $Message
+}
+
+$solutionRoot = Join-Path $PSScriptRoot "..\..\ProjectPortfolio2026"
+$resultsRoot = Join-Path $solutionRoot "TestResults"
+$coverageSettingsPath = Join-Path $solutionRoot "coverage.runsettings"
+$minimumCoverage = if ($env:MINIMUM_COVERAGE) { [double]$env:MINIMUM_COVERAGE } else { 70.0 }
+$enforceCoverageGate = $true
+
+if ($env:ENFORCE_COVERAGE_GATE) {
+    $enforceCoverageGate = $env:ENFORCE_COVERAGE_GATE -eq "true"
+}
+
+try {
+    if (Test-Path -LiteralPath $resultsRoot) {
+        Remove-Item -LiteralPath $resultsRoot -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $resultsRoot | Out-Null
+
+    if (-not (Test-Path -LiteralPath $coverageSettingsPath)) {
+        Fail-Check "Coverage settings file was not found at '$coverageSettingsPath'."
+    }
+
+    $testProjects = Get-ChildItem -Path $solutionRoot -Recurse -Filter *.csproj |
+        Where-Object { $_.Name -match 'Tests?\.csproj$' -or $_.BaseName -match 'Tests?$' }
+
+    if (-not $testProjects -and $enforceCoverageGate) {
+        Fail-Check "No .NET test projects were found. Add unit tests to satisfy repository policy."
+    }
+
+    if (-not $testProjects) {
+        Write-Host "::warning::No .NET test projects were found. Coverage is being reported as advisory because coverage enforcement is disabled for this branch."
+        if ($env:GITHUB_STEP_SUMMARY) {
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Coverage Check Warning"
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ""
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "No .NET test projects were found. Coverage enforcement is disabled for this branch."
+        }
+        return
+    }
+
+    foreach ($project in $testProjects) {
+        $projectXml = Get-Content -LiteralPath $project.FullName -Raw
+        $hasCoverageCollector =
+            $projectXml -match 'coverlet\.collector' -or
+            $projectXml -match 'coverlet\.msbuild' -or
+            $projectXml -match 'Microsoft\.Testing\.Extensions\.CodeCoverage'
+
+        if (-not $hasCoverageCollector) {
+            Fail-Check "Test project '$($project.Name)' does not declare a supported coverage collector package."
+        }
+
+        dotnet test $project.FullName `
+            --configuration Release `
+            --logger "trx" `
+            --results-directory $resultsRoot `
+            --settings $coverageSettingsPath `
+            --collect:"XPlat Code Coverage"
+    }
+
+    $coverageFiles = Get-ChildItem -Path $resultsRoot -Recurse -Filter coverage.cobertura.xml
+
+    if (-not $coverageFiles) {
+        Fail-Check "Coverage output was not generated. Ensure the test projects include a supported coverage collector."
+    }
+
+    [double]$coveredLines = 0
+    [double]$validLines = 0
+
+    foreach ($file in $coverageFiles) {
+        [xml]$coverageXml = Get-Content -LiteralPath $file.FullName
+        $coveredLines += [double]$coverageXml.coverage.'lines-covered'
+        $validLines += [double]$coverageXml.coverage.'lines-valid'
+    }
+
+    if ($validLines -le 0) {
+        Fail-Check "Coverage report did not contain any measurable lines."
+    }
+
+    $coveragePercent = [math]::Round(($coveredLines / $validLines) * 100, 2)
+    Write-Host "Combined .NET line coverage: $coveragePercent%"
+
+    if ($env:GITHUB_STEP_SUMMARY) {
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "## Coverage Check Result"
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ""
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "Combined .NET line coverage: $coveragePercent%"
+    }
+
+    if ($coveragePercent -lt $minimumCoverage -and $enforceCoverageGate) {
+        Fail-Check "Coverage check failed. Required: $minimumCoverage%. Actual: $coveragePercent%."
+    }
+
+    if ($coveragePercent -lt $minimumCoverage) {
+        Write-Host "::warning::Coverage is below the $minimumCoverage% target, but coverage enforcement is disabled for this branch. Actual: $coveragePercent%."
+        if ($env:GITHUB_STEP_SUMMARY) {
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ""
+            Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "Coverage is below the target, but enforcement is disabled for this branch."
+        }
+    }
+}
+catch {
+    if (-not $_.Exception.Message) {
+        throw
+    }
+
+    throw $_
+}

--- a/.github/workflows/branch-promotion.yml
+++ b/.github/workflows/branch-promotion.yml
@@ -1,0 +1,29 @@
+name: branch-promotion
+
+on:
+  pull_request:
+    branches:
+      - main
+      - stage
+
+jobs:
+  validate-branch-promotion:
+    name: validate-branch-promotion
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate allowed source branch
+        shell: pwsh
+        run: |
+          $baseRef = "${{ github.base_ref }}"
+          $headRef = "${{ github.head_ref }}"
+
+          Write-Host "Validating pull request source branch '$headRef' for target '$baseRef'."
+
+          if ($baseRef -eq "main" -and $headRef -ne "stage") {
+              Write-Error "Pull requests into 'main' must come from 'stage'."
+          }
+
+          if ($baseRef -eq "stage" -and $headRef -ne "dev") {
+              Write-Error "Pull requests into 'stage' must come from 'dev'."
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+      - stage
+      - dev
+  pull_request:
+    branches:
+      - main
+      - stage
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build-test-and-coverage:
+    name: build-test-and-coverage
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    env:
+      SOLUTION_ROOT: ProjectPortfolio2026
+      CLIENT_ROOT: ProjectPortfolio2026/projectportfolio2026.client
+      SERVER_ROOT: ProjectPortfolio2026/ProjectPortfolio2026.Server
+      SOLUTION_FILE: ProjectPortfolio2026/ProjectPortfolio2026.slnx
+      MINIMUM_COVERAGE: 70
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Determine coverage enforcement
+        id: coverage-policy
+        run: |
+          $targetBranch = if ("${{ github.event_name }}" -eq "pull_request") { "${{ github.base_ref }}" } else { "${{ github.ref_name }}" }
+          $enforceCoverageGate = if ($targetBranch -in @("main", "stage")) { "true" } else { "false" }
+
+          "target_branch=$targetBranch" >> $env:GITHUB_OUTPUT
+          "enforce_coverage_gate=$enforceCoverageGate" >> $env:GITHUB_OUTPUT
+
+          Write-Host "Coverage enforcement for branch '$targetBranch': $enforceCoverageGate"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: ProjectPortfolio2026/projectportfolio2026.client/package-lock.json
+
+      - name: Restore client dependencies
+        working-directory: ${{ env.CLIENT_ROOT }}
+        run: npm ci
+
+      - name: Lint client
+        working-directory: ${{ env.CLIENT_ROOT }}
+        run: npm run lint
+
+      - name: Build client
+        working-directory: ${{ env.CLIENT_ROOT }}
+        run: npm run build
+
+      - name: Restore .NET solution
+        run: dotnet restore $env:SOLUTION_FILE
+
+      - name: Build .NET solution
+        run: dotnet build $env:SOLUTION_FILE --configuration Release --no-restore
+
+      - name: Run .NET tests with coverage gate
+        env:
+          ENFORCE_COVERAGE_GATE: ${{ steps.coverage-policy.outputs.enforce_coverage_gate }}
+        run: ./.github/scripts/run-dotnet-tests-with-coverage.ps1
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ProjectPortfolio2026/TestResults
+          if-no-files-found: ignore

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -30,3 +30,5 @@
 ## Knowledge Capture
 
 - When errors require a workaround to complete a user task, document the workaround in `AGENTS.MD` so future tasks can be completed faster.
+- When `gh api` payloads become fragile in PowerShell because of quoting, prefer direct `gh` commands or write JSON to a temporary file before calling the API.
+- Avoid running `dotnet build` and `dotnet test` in parallel against the same solution or projects on Windows, because file locks in `bin/obj` can cause build failures.

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectPortfolio2026.Server\ProjectPortfolio2026.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/UnitTest1.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/UnitTest1.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Controllers;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public class UnitTest1
+{
+    [Test]
+    public void Get_ReturnsFiveForecastEntries()
+    {
+        var controller = new WeatherForecastController();
+
+        var result = controller.Get().ToArray();
+
+        Assert.That(result, Has.Length.EqualTo(5));
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.slnx
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.slnx
@@ -3,5 +3,6 @@
     <Build />
     <Deploy />
   </Project>
+  <Project Path="ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj" />
   <Project Path="ProjectPortfolio2026.Server/ProjectPortfolio2026.Server.csproj" />
 </Solution>

--- a/ProjectPortfolio2026/coverage.runsettings
+++ b/ProjectPortfolio2026/coverage.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <ExcludeByFile>**/Program.cs,**/*.generated.cs,**/obj/**/*.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary
Promotes the current `stage` branch into `main`.

## Included Changes
- Adds GitHub Actions policy checks and clearer workflow failure reporting.
- Adds CI and branch promotion workflows.
- Adds a default server test project and converts the default tests to NUnit.
- Adds a coverage settings file and a PowerShell helper script to run .NET tests with coverage.
- Limits the coverage gate to `stage` and `main`.
- Removes the test project solution exclusion and updates the solution file.
- Adds AGENTS guidance about fragile `gh api` payload quoting and Windows `dotnet build` / `dotnet test` file-lock conflicts.
- Includes the `dev -> stage` promotion merge commit from PR #19.

## Commits In This Promotion
- `18ee189` Codex - Add GitHub Actions Policy Checks
- `a8ee3b4` Codex - Surface Workflow Failure Reasons
- `d2b50af` Codex - Add Default Server Test Project
- `79ad4b6` Codex - Limit Coverage Gate To Stage And Main
- `017641e` Codex - Convert Default Tests To NUnit
- `f574481` Merge pull request #12 from darkdhamon/codex/11-actions-branch-checks
- `baa61a7` Update ProjectPortfolio2026.slnx
- `dbf43db` Codex - Remove Test Project Solution Exclusion
- `4448308` Merge pull request #16 from darkdhamon/codex/15-slnx-followup
- `374dde2` Codex - Add coverage exclusions
- `aa787de` Merge branch 'dev' into codex/7-coverage-exclusions
- `afd29a9` Merge pull request #18 from darkdhamon/codex/7-coverage-exclusions
- `2780c59` Merge pull request #19 from darkdhamon/dev

## Scope
- 13 commits
- 8 changed files
- 294 additions