### PR TITLE
Add public site navigation shell

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -35,3 +35,4 @@
 - If `dotnet ef` is unavailable when generating Entity Framework migrations, install the matching `dotnet-ef` tool version first before retrying the migration command.
 - When the .NET coverage collector writes empty Cobertura files under a `TestResults` directory on Windows, switch the coverage script to a different results folder name such as `CoverageResults`.
 - If PowerShell cannot resolve `node` or `npm` on Windows, verify that the Node.js toolchain is installed before attempting frontend dependency changes or client build verification.
+- If Visual Studio deployment for the `.esproj` fails with `Value cannot be null. Parameter name: source` while referencing `launch.json`, restore or recreate `projectportfolio2026.client/.vscode/launch.json`; the JavaScript project template expects that debug profile to exist.

--- a/ProjectPortfolio2026/projectportfolio2026.client/.gitignore
+++ b/ProjectPortfolio2026/projectportfolio2026.client/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
+!.vscode/launch.json
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/ProjectPortfolio2026/projectportfolio2026.client/.vscode/launch.json
+++ b/ProjectPortfolio2026/projectportfolio2026.client/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Microsoft Edge",
+      "type": "msedge",
+      "request": "launch",
+      "url": "https://localhost:54307",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1,3 +1,163 @@
+.site-shell {
+    display: grid;
+    grid-template-columns: minmax(15rem, 18rem) minmax(0, 1fr);
+    min-height: 100vh;
+    background:
+        radial-gradient(circle at bottom left, rgba(111, 24, 79, 0.24), transparent 18%),
+        linear-gradient(180deg, #091321 0%, #0d1828 100%);
+}
+
+.site-sidebar {
+    position: sticky;
+    top: 0;
+    display: grid;
+    align-content: start;
+    gap: 1.4rem;
+    min-height: 100vh;
+    padding: 1.25rem 1rem;
+    border-right: 1px solid rgba(111, 137, 171, 0.16);
+    background:
+        linear-gradient(180deg, rgba(9, 19, 33, 0.98), rgba(8, 17, 31, 0.94)),
+        radial-gradient(circle at top left, rgba(72, 113, 184, 0.2), transparent 35%);
+    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04);
+}
+
+.site-brand,
+.site-nav,
+.site-header {
+    display: grid;
+}
+
+.site-brand {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: start;
+    padding: 0.95rem 1rem;
+    border: 1px solid rgba(111, 137, 171, 0.16);
+    border-radius: 1.2rem;
+    background: rgba(15, 31, 54, 0.78);
+}
+
+.brand-mark,
+.brand-copy,
+.sidebar-footnote,
+.header-kicker,
+.site-header-copy {
+    margin: 0;
+}
+
+.brand-mark {
+    display: grid;
+    place-items: center;
+    width: 3rem;
+    aspect-ratio: 1;
+    border-radius: 1rem;
+    background:
+        radial-gradient(circle at top left, rgba(245, 183, 48, 0.3), transparent 55%),
+        linear-gradient(145deg, rgba(26, 66, 118, 0.96), rgba(17, 36, 62, 0.96));
+    color: #f4f8fe;
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+}
+
+.site-brand strong,
+.site-title {
+    color: #f4f8fe;
+}
+
+.brand-copy,
+.sidebar-footnote,
+.site-header-copy {
+    color: rgba(213, 224, 239, 0.76);
+    line-height: 1.6;
+}
+
+.site-nav {
+    gap: 0.65rem;
+}
+
+.nav-link {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+    min-height: 3rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid rgba(111, 137, 171, 0.14);
+    border-radius: 1rem;
+    background: rgba(11, 26, 45, 0.72);
+    color: #dce7f5;
+    font-weight: 600;
+    text-align: left;
+    text-decoration: none;
+}
+
+.nav-link.active {
+    border-color: rgba(245, 183, 48, 0.55);
+    background:
+        linear-gradient(135deg, rgba(25, 56, 99, 0.96), rgba(16, 34, 58, 0.96));
+    color: #fff7e8;
+    box-shadow: 0 16px 30px rgba(6, 14, 27, 0.34);
+}
+
+.nav-link-disabled {
+    cursor: not-allowed;
+    opacity: 1;
+}
+
+.nav-link-disabled:disabled {
+    color: rgba(220, 231, 245, 0.82);
+}
+
+.coming-soon-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.28rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(245, 183, 48, 0.16);
+    color: #ffd77d;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.sidebar-footnote {
+    padding: 0 0.2rem;
+    font-size: 0.9rem;
+}
+
+.site-main {
+    display: grid;
+    align-content: start;
+    gap: 1.25rem;
+    min-width: 0;
+    padding-right: 2rem;
+}
+
+.site-header {
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 30rem);
+    gap: 1rem;
+    align-items: center;
+    padding: 1.4rem 2rem 0;
+}
+
+.header-kicker {
+    color: #ffd77d;
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+}
+
+.site-title {
+    margin: 0.15rem 0 0;
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
 .portfolio-page {
     display: grid;
     gap: 1.5rem;
@@ -201,7 +361,8 @@
 .skill-chip:hover,
 .card-links a:hover,
 .back-link:hover,
-.inline-links a:hover {
+.inline-links a:hover,
+.nav-link:hover {
     transform: translateY(-1px);
 }
 
@@ -620,6 +781,23 @@ h3 {
 }
 
 @media (max-width: 900px) {
+    .site-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .site-sidebar {
+        position: static;
+        min-height: auto;
+        padding-bottom: 1rem;
+        border-right: 0;
+        border-bottom: 1px solid rgba(111, 137, 171, 0.16);
+    }
+
+    .site-header {
+        grid-template-columns: 1fr;
+        padding-top: 1rem;
+    }
+
     .detail-hero,
     .project-card,
     .detail-grid {
@@ -632,8 +810,18 @@ h3 {
 }
 
 @media (max-width: 720px) {
+    .site-sidebar,
+    .site-header,
     .portfolio-page {
         padding: 1rem;
+    }
+
+    .site-main {
+        padding-right: 0;
+    }
+
+    .site-nav {
+        grid-template-columns: 1fr;
     }
 
     .sticky-filters {
@@ -659,6 +847,10 @@ h3 {
 
     .clear-button {
         width: 100%;
+    }
+
+    .nav-link {
+        grid-template-columns: 1fr auto;
     }
 
     .image-shell,

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -59,6 +59,9 @@ describe('App', () => {
         expect(await screen.findByRole('heading', { name: 'Portfolio Refresh' })).toBeInTheDocument();
         expect(screen.getByText('Published Projects')).toBeInTheDocument();
         expect(screen.getByText('Visible Cards')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Projects' })).toHaveAttribute('aria-current', 'page');
+        expect(screen.getByRole('button', { name: /Home/i })).toBeDisabled();
+        expect(screen.getAllByText('Coming Soon').length).toBeGreaterThan(0);
         expect(screen.getByRole('button', { name: 'React' })).toHaveAttribute('aria-pressed', 'false');
         expect(fetchMock).toHaveBeenCalledWith('/api/projects?page=1&pageSize=6&requestId=request-1', expect.any(Object));
     });
@@ -108,6 +111,7 @@ describe('App', () => {
         render(<App />);
 
         expect(await screen.findByRole('heading', { name: 'Portfolio Refresh' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Projects' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getByRole('link', { name: 'Back to project list' })).toHaveAttribute('href', '/?search=react&skills=Testing');
     });
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { startTransition, useDeferredValue, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import profilePlaceholder from './assets/Placeholders/Profile-Placeholder.png';
 import projectImageUnavailable from './assets/Placeholders/Project-Image-Unavailable.png';
 import screenshotMissing from './assets/Placeholders/Screenshot-Missing.png';
@@ -89,6 +89,15 @@ interface ApiErrorResponse {
 }
 
 const pageSize = 6;
+const navItems = [
+    { label: 'Projects', href: '/', description: 'Browse shipped work and project detail stories.' },
+    { label: 'Home', description: 'Featured highlights and introduction.' },
+    { label: 'Timeline', description: 'Career milestones, education, and certifications.' },
+    { label: 'About', description: 'Background, strengths, and developer story.' },
+    { label: 'Resume', description: 'Resume hub and downloadable materials.' },
+    { label: 'Contact', description: 'Direct outreach paths and social links.' },
+    { label: 'Blog', description: 'Writing, updates, and thought pieces.' }
+] as const;
 
 function App() {
     const [location, setLocation] = useState<AppLocation>(() => readLocation());
@@ -103,6 +112,7 @@ function App() {
     }, []);
 
     const route = useMemo(() => parseRoute(location), [location]);
+    const activeNavLabel = route.kind === 'detail' || route.kind === 'list' ? 'Projects' : '';
 
     function navigate(nextPath: string, options?: { replace?: boolean; preserveScroll?: boolean }) {
         const method = options?.replace ? 'replaceState' : 'pushState';
@@ -114,19 +124,86 @@ function App() {
         }
     }
 
-    if (route.kind === 'detail') {
-        return (
-            <ProjectDetailPage
-                projectId={route.projectId}
-                listSearch={route.listSearch}
-                onNavigate={navigate} />
-        );
-    }
-
     return (
-        <ProjectListPage
-            filters={route.filters}
-            onNavigate={navigate} />
+        <SiteShell
+            activeNavLabel={activeNavLabel}
+            onNavigate={navigate}>
+            {route.kind === 'detail' ? (
+                <ProjectDetailPage
+                    projectId={route.projectId}
+                    listSearch={route.listSearch}
+                    onNavigate={navigate} />
+            ) : (
+                <ProjectListPage
+                    filters={route.filters}
+                    onNavigate={navigate} />
+            )}
+        </SiteShell>
+    );
+}
+
+function SiteShell({
+    activeNavLabel,
+    onNavigate,
+    children
+}: {
+    activeNavLabel: string;
+    onNavigate: (path: string, options?: { replace?: boolean; preserveScroll?: boolean }) => void;
+    children: ReactNode;
+}) {
+    return (
+        <div className="site-shell">
+            <aside className="site-sidebar" aria-label="Primary">
+                <div className="site-brand">
+                    <p className="brand-mark">PP26</p>
+                    <div>
+                        <strong>Project Portfolio</strong>
+                        <p className="brand-copy">Built to scale as new public sections come online.</p>
+                    </div>
+                </div>
+
+                <nav className="site-nav" aria-label="Primary site navigation">
+                    {navItems.map(item => item.href ? (
+                        <InternalLink
+                            key={item.label}
+                            className={`nav-link${activeNavLabel === item.label ? ' active' : ''}`}
+                            href={item.href}
+                            ariaCurrent={activeNavLabel === item.label ? 'page' : undefined}
+                            onNavigate={onNavigate}>
+                            {item.label}
+                        </InternalLink>
+                    ) : (
+                        <button
+                            key={item.label}
+                            className="nav-link nav-link-disabled"
+                            type="button"
+                            disabled
+                            aria-disabled="true">
+                            <span>{item.label}</span>
+                            <span className="coming-soon-pill">Coming Soon</span>
+                        </button>
+                    ))}
+                </nav>
+
+                <p className="sidebar-footnote">
+                    Resume will eventually include the Work History subsection.
+                </p>
+            </aside>
+
+            <div className="site-main">
+                <header className="site-header">
+                    <div>
+                        <p className="header-kicker">Public Portfolio</p>
+                        <h1 className="site-title">Navigation Preview</h1>
+                    </div>
+                    <p className="site-header-copy">
+                        Projects are live now. Planned sections are visible to establish the long-term site structure.
+                    </p>
+                </header>
+
+                {children}
+            </div>
+        </div>
     );
 }
 
@@ -752,12 +829,14 @@ function ProjectDetailPage({
 function InternalLink({
     className,
     href,
+    ariaCurrent,
     onNavigate,
     children,
     preserveScroll
 }: {
     className?: string;
     href: string;
+    ariaCurrent?: 'page';
     onNavigate: (path: string, options?: { replace?: boolean; preserveScroll?: boolean }) => void;
     children: string;
     preserveScroll?: boolean;
@@ -766,6 +845,7 @@ function InternalLink({
         <a
             className={className}
             href={href}
+            aria-current={ariaCurrent}
             onClick={event => {
                 event.preventDefault();
                 onNavigate(href, { preserveScroll });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
@@ -88,8 +88,20 @@ interface ApiErrorResponse {
     message?: string;
 }
 
+interface SiteShellContent {
+    kicker: string;
+    title: string;
+    summary: string;
+}
+
+interface NavItem {
+    label: string;
+    description: string;
+    href?: string;
+}
+
 const pageSize = 6;
-const navItems = [
+const navItems: readonly NavItem[] = [
     { label: 'Projects', href: '/', description: 'Browse shipped work and project detail stories.' },
     { label: 'Home', description: 'Featured highlights and introduction.' },
     { label: 'Timeline', description: 'Career milestones, education, and certifications.' },
@@ -113,6 +125,17 @@ function App() {
 
     const route = useMemo(() => parseRoute(location), [location]);
     const activeNavLabel = route.kind === 'detail' || route.kind === 'list' ? 'Projects' : '';
+    const shellContent = route.kind === 'detail'
+        ? {
+            kicker: 'Project Portfolio',
+            title: 'Project Detail',
+            summary: 'Review the project story, supporting media, collaborators, and milestone context.'
+        } satisfies SiteShellContent
+        : {
+            kicker: 'Project Portfolio',
+            title: 'Projects',
+            summary: 'Browse shipped work, search the portfolio, and move into individual project case studies.'
+        } satisfies SiteShellContent;
 
     function navigate(nextPath: string, options?: { replace?: boolean; preserveScroll?: boolean }) {
         const method = options?.replace ? 'replaceState' : 'pushState';
@@ -127,6 +150,7 @@ function App() {
     return (
         <SiteShell
             activeNavLabel={activeNavLabel}
+            content={shellContent}
             onNavigate={navigate}>
             {route.kind === 'detail' ? (
                 <ProjectDetailPage
@@ -144,10 +168,12 @@ function App() {
 
 function SiteShell({
     activeNavLabel,
+    content,
     onNavigate,
     children
 }: {
     activeNavLabel: string;
+    content: SiteShellContent;
     onNavigate: (path: string, options?: { replace?: boolean; preserveScroll?: boolean }) => void;
     children: ReactNode;
 }) {
@@ -193,12 +219,10 @@ function SiteShell({
             <div className="site-main">
                 <header className="site-header">
                     <div>
-                        <p className="header-kicker">Public Portfolio</p>
-                        <h1 className="site-title">Navigation Preview</h1>
+                        <p className="header-kicker">{content.kicker}</p>
+                        <p className="site-title">{content.title}</p>
                     </div>
-                    <p className="site-header-copy">
-                        Projects are live now. Planned sections are visible to establish the long-term site structure.
-                    </p>
+                    <p className="site-header-copy">{content.summary}</p>
                 </header>
 
                 {children}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/index.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/index.css
@@ -22,8 +22,8 @@ body {
 }
 
 #root {
-  width: min(1180px, 100%);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
Addresses #31 by introducing the first pass of the public site navigation shell and placeholder navigation structure for planned sections.

## Issues Addressed
- #31 Design site navigation with user collaboration

## Included Changes
- Added a left-side public navigation shell with `Projects` as the active live section
- Added disabled `Coming Soon` placeholders for planned sections including Home, Timeline, About, Resume, Contact, and Blog
- Added a slim public header and widened the client shell so the content pane uses the viewport more effectively
- Restored the client `.vscode/launch.json` profile used by Visual Studio JavaScript project deployment
- Updated the client `.gitignore` so the launch profile can be tracked
- Documented the Visual Studio deploy workaround in `AGENTS.MD`
- Added test coverage for the active navigation state and placeholder nav entries

## Validation
- `npm run test`
- `npm run lint`

## Commits
- `88ab679` Codex - Add public site navigation shell

## Scope
This PR focuses on the navigation shell, placeholder public information architecture, and the Visual Studio client launch-profile fix. Content-pane refinement and broader theme work are tracked separately in #36 and #37.