### PR TITLE
Codex - Create Contact Page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           "should_run_tests=$shouldRunTests" >> $env:GITHUB_OUTPUT
 
           if ($changedFiles.Count -gt 0) {
-            Write-Host "Changed files detected relative to $baseCommit:"
+            Write-Host "Changed files detected relative to ${baseCommit}:"
             $changedFiles | ForEach-Object { Write-Host " - $_" }
           }
           else {

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioDbContextTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioDbContextTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 using ProjectPortfolio2026.Server.Data;
 using ProjectPortfolio2026.Server.Domain.Identity;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
 using ProjectPortfolio2026.Server.Domain.Projects;
 
 namespace ProjectPortfolio2026.Server.Tests;
@@ -18,6 +19,9 @@ public sealed class PortfolioDbContextTests
         Assert.Multiple(() =>
         {
             Assert.That(dbContext.ApplicationUsers, Is.Not.Null);
+            Assert.That(dbContext.PortfolioProfiles, Is.Not.Null);
+            Assert.That(dbContext.PortfolioContactMethods, Is.Not.Null);
+            Assert.That(dbContext.PortfolioSocialLinks, Is.Not.Null);
             Assert.That(dbContext.Projects, Is.Not.Null);
             Assert.That(dbContext.ProjectCollaborators, Is.Not.Null);
             Assert.That(dbContext.ProjectCollaboratorRoles, Is.Not.Null);
@@ -28,6 +32,9 @@ public sealed class PortfolioDbContextTests
             Assert.That(dbContext.ProjectTechnologies, Is.Not.Null);
             Assert.That(dbContext.Model.FindEntityType(typeof(ApplicationUser))?.GetTableName(), Is.EqualTo("AspNetUsers"));
             Assert.That(dbContext.Model.FindEntityType(typeof(IdentityRole))?.GetTableName(), Is.EqualTo("AspNetRoles"));
+            Assert.That(dbContext.Model.FindEntityType(typeof(PortfolioProfile))?.GetTableName(), Is.EqualTo("PortfolioProfiles"));
+            Assert.That(dbContext.Model.FindEntityType(typeof(PortfolioContactMethod))?.GetTableName(), Is.EqualTo("PortfolioContactMethods"));
+            Assert.That(dbContext.Model.FindEntityType(typeof(PortfolioSocialLink))?.GetTableName(), Is.EqualTo("PortfolioSocialLinks"));
             Assert.That(dbContext.Model.FindEntityType(typeof(Project))?.GetTableName(), Is.EqualTo("Projects"));
             Assert.That(dbContext.Model.FindEntityType(typeof(ProjectCollaborator))?.GetTableName(), Is.EqualTo("ProjectCollaborators"));
             Assert.That(dbContext.Model.FindEntityType(typeof(ProjectCollaboratorRole))?.GetTableName(), Is.EqualTo("ProjectCollaboratorRoles"));
@@ -36,6 +43,9 @@ public sealed class PortfolioDbContextTests
             Assert.That(dbContext.Model.FindEntityType(typeof(ProjectScreenshot))?.GetTableName(), Is.EqualTo("ProjectScreenshots"));
             Assert.That(dbContext.Model.FindEntityType(typeof(ProjectSkill))?.GetTableName(), Is.EqualTo("ProjectSkills"));
             Assert.That(dbContext.Model.FindEntityType(typeof(ProjectTechnology))?.GetTableName(), Is.EqualTo("ProjectTechnologies"));
+            Assert.That(dbContext.Model.FindEntityType(typeof(PortfolioProfile))?.FindProperty(nameof(PortfolioProfile.DisplayName))?.GetMaxLength(), Is.EqualTo(200));
+            Assert.That(dbContext.Model.FindEntityType(typeof(PortfolioContactMethod))?.FindProperty(nameof(PortfolioContactMethod.Value))?.GetMaxLength(), Is.EqualTo(250));
+            Assert.That(dbContext.Model.FindEntityType(typeof(PortfolioSocialLink))?.FindProperty(nameof(PortfolioSocialLink.Url))?.GetMaxLength(), Is.EqualTo(500));
             Assert.That(dbContext.Model.FindEntityType(typeof(ApplicationUser))?.FindProperty(nameof(ApplicationUser.DisplayName))?.GetMaxLength(), Is.EqualTo(256));
             Assert.That(dbContext.Model.FindEntityType(typeof(ApplicationUser))?.GetIndexes().Any(index =>
                 index.Properties.Select(property => property.Name).SequenceEqual([nameof(ApplicationUser.NormalizedEmail)]) &&

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioLinkFormatterTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioLinkFormatterTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Services.Implementations;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class PortfolioLinkFormatterTests
+{
+    private readonly PortfolioLinkFormatter formatter = new();
+
+    [Test]
+    public void BuildContactMethodHref_GeneratesMailToAndTelephoneLinks()
+    {
+        var emailContact = new PortfolioContactMethod
+        {
+            Type = "email",
+            Value = "bronze@example.dev"
+        };
+        var phoneContact = new PortfolioContactMethod
+        {
+            Type = "phone",
+            Value = "(312) 555-0147"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(formatter.BuildContactMethodHref(emailContact), Is.EqualTo("mailto:bronze@example.dev"));
+            Assert.That(formatter.BuildContactMethodHref(phoneContact), Is.EqualTo("tel:3125550147"));
+        });
+    }
+
+    [Test]
+    public void BuildContactMethodHref_FiltersUnsafeOrInvalidValues()
+    {
+        var customContact = new PortfolioContactMethod
+        {
+            Type = "portfolio",
+            Value = "Portfolio site",
+            Href = "javascript:alert('xss')"
+        };
+        var invalidEmailContact = new PortfolioContactMethod
+        {
+            Type = "email",
+            Value = "not-an-email"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(formatter.BuildContactMethodHref(customContact), Is.Null);
+            Assert.That(formatter.BuildContactMethodHref(invalidEmailContact), Is.Null);
+        });
+    }
+
+    [Test]
+    public void BuildSocialLinkUrl_OnlyAllowsHttpAndHttps()
+    {
+        var safeSocialLink = new PortfolioSocialLink
+        {
+            Url = "https://github.com/darkdhamon"
+        };
+        var unsafeSocialLink = new PortfolioSocialLink
+        {
+            Url = "javascript:alert('xss')"
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(formatter.BuildSocialLinkUrl(safeSocialLink), Is.EqualTo("https://github.com/darkdhamon"));
+            Assert.That(formatter.BuildSocialLinkUrl(unsafeSocialLink), Is.Null);
+        });
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileContractMapperTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileContractMapperTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using ProjectPortfolio2026.Server.Domain.Portfolio;
 using ProjectPortfolio2026.Server.Mappers;
+using ProjectPortfolio2026.Server.Services.Interfaces;
 
 namespace ProjectPortfolio2026.Server.Tests;
 
@@ -8,7 +9,7 @@ namespace ProjectPortfolio2026.Server.Tests;
 public sealed class PortfolioProfileContractMapperTests
 {
     [Test]
-    public void ToResponse_GeneratesEmailAndPhoneLinks_AndFiltersUnsafeLinks()
+    public void ToResponse_MapsVisibleContactMethodsAndSocialLinks_UsingFormatter()
     {
         var profile = new PortfolioProfile
         {
@@ -16,7 +17,6 @@ public sealed class PortfolioProfileContractMapperTests
             DisplayName = "Bronze Loft",
             ContactHeadline = "Reach out",
             ContactIntro = "Intro",
-            IsPublic = true,
             ContactMethods =
             [
                 new PortfolioContactMethod
@@ -24,27 +24,16 @@ public sealed class PortfolioProfileContractMapperTests
                     Type = "email",
                     Label = "Email",
                     Value = "bronze@example.dev",
-                    Href = "javascript:alert('xss')",
                     SortOrder = 1,
                     IsVisible = true
                 },
                 new PortfolioContactMethod
                 {
-                    Type = "phone",
-                    Label = "Phone",
-                    Value = "(312) 555-0147",
-                    Href = "https://ignored.example.test",
+                    Type = "hidden",
+                    Label = "Hidden",
+                    Value = "Hidden",
                     SortOrder = 2,
-                    IsVisible = true
-                },
-                new PortfolioContactMethod
-                {
-                    Type = "portfolio",
-                    Label = "Website",
-                    Value = "Portfolio site",
-                    Href = "javascript:alert('xss')",
-                    SortOrder = 3,
-                    IsVisible = true
+                    IsVisible = false
                 }
             ],
             SocialLinks =
@@ -59,25 +48,39 @@ public sealed class PortfolioProfileContractMapperTests
                 },
                 new PortfolioSocialLink
                 {
-                    Platform = "unsafe",
-                    Label = "Unsafe",
-                    Url = "javascript:alert('xss')",
+                    Platform = "unsupported",
+                    Label = "Unsupported",
+                    Url = "ignored",
                     SortOrder = 2,
                     IsVisible = true
                 }
             ]
         };
 
-        var response = profile.ToResponse("request-1");
+        var response = profile.ToResponse(new StubPortfolioLinkFormatter(), "request-1");
 
         Assert.Multiple(() =>
         {
-            Assert.That(response.ContactMethods, Has.Count.EqualTo(3));
-            Assert.That(response.ContactMethods[0].Href, Is.EqualTo("mailto:bronze@example.dev"));
-            Assert.That(response.ContactMethods[1].Href, Is.EqualTo("tel:3125550147"));
-            Assert.That(response.ContactMethods[2].Href, Is.Null);
-            Assert.That(response.SocialLinks.Select(link => link.Label), Is.EqualTo(new[] { "GitHub" }));
+            Assert.That(response.RequestId, Is.EqualTo("request-1"));
+            Assert.That(response.ContactMethods.Select(contactMethod => contactMethod.Label), Is.EqualTo(new[] { "Email" }));
+            Assert.That(response.ContactMethods[0].Href, Is.EqualTo("formatted:email"));
+            Assert.That(response.SocialLinks.Select(socialLink => socialLink.Label), Is.EqualTo(new[] { "GitHub" }));
             Assert.That(response.SocialLinks[0].Url, Is.EqualTo("https://github.com/darkdhamon"));
         });
+    }
+
+    private sealed class StubPortfolioLinkFormatter : IPortfolioLinkFormatter
+    {
+        public string? BuildContactMethodHref(PortfolioContactMethod contactMethod)
+        {
+            return $"formatted:{contactMethod.Type}";
+        }
+
+        public string? BuildSocialLinkUrl(PortfolioSocialLink socialLink)
+        {
+            return socialLink.Platform.Equals("github", StringComparison.OrdinalIgnoreCase)
+                ? socialLink.Url
+                : null;
+        }
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileContractMapperTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileContractMapperTests.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Mappers;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class PortfolioProfileContractMapperTests
+{
+    [Test]
+    public void ToResponse_GeneratesEmailAndPhoneLinks_AndFiltersUnsafeLinks()
+    {
+        var profile = new PortfolioProfile
+        {
+            Id = 9,
+            DisplayName = "Bronze Loft",
+            ContactHeadline = "Reach out",
+            ContactIntro = "Intro",
+            IsPublic = true,
+            ContactMethods =
+            [
+                new PortfolioContactMethod
+                {
+                    Type = "email",
+                    Label = "Email",
+                    Value = "bronze@example.dev",
+                    Href = "javascript:alert('xss')",
+                    SortOrder = 1,
+                    IsVisible = true
+                },
+                new PortfolioContactMethod
+                {
+                    Type = "phone",
+                    Label = "Phone",
+                    Value = "(312) 555-0147",
+                    Href = "https://ignored.example.test",
+                    SortOrder = 2,
+                    IsVisible = true
+                },
+                new PortfolioContactMethod
+                {
+                    Type = "portfolio",
+                    Label = "Website",
+                    Value = "Portfolio site",
+                    Href = "javascript:alert('xss')",
+                    SortOrder = 3,
+                    IsVisible = true
+                }
+            ],
+            SocialLinks =
+            [
+                new PortfolioSocialLink
+                {
+                    Platform = "github",
+                    Label = "GitHub",
+                    Url = "https://github.com/darkdhamon",
+                    SortOrder = 1,
+                    IsVisible = true
+                },
+                new PortfolioSocialLink
+                {
+                    Platform = "unsafe",
+                    Label = "Unsafe",
+                    Url = "javascript:alert('xss')",
+                    SortOrder = 2,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var response = profile.ToResponse("request-1");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.ContactMethods, Has.Count.EqualTo(3));
+            Assert.That(response.ContactMethods[0].Href, Is.EqualTo("mailto:bronze@example.dev"));
+            Assert.That(response.ContactMethods[1].Href, Is.EqualTo("tel:3125550147"));
+            Assert.That(response.ContactMethods[2].Href, Is.Null);
+            Assert.That(response.SocialLinks.Select(link => link.Label), Is.EqualTo(new[] { "GitHub" }));
+            Assert.That(response.SocialLinks[0].Url, Is.EqualTo("https://github.com/darkdhamon"));
+        });
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileControllerTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Contracts.Portfolio;
+using ProjectPortfolio2026.Server.Controllers;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Repositories;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class PortfolioProfileControllerTests
+{
+    [Test]
+    public async Task GetAsync_ReturnsPublicProfileWithRequestId()
+    {
+        var repository = new StubPortfolioProfileRepository
+        {
+            Profile = new PortfolioProfile
+            {
+                Id = 7,
+                DisplayName = "Bronze Loft",
+                ContactHeadline = "Reach out",
+                ContactIntro = "Public intro",
+                IsPublic = true,
+                ContactMethods =
+                [
+                    new PortfolioContactMethod
+                    {
+                        Type = "email",
+                        Label = "Email",
+                        Value = "bronze@example.dev",
+                        Href = "mailto:bronze@example.dev",
+                        SortOrder = 1,
+                        IsVisible = true
+                    },
+                    new PortfolioContactMethod
+                    {
+                        Type = "phone",
+                        Label = "Phone",
+                        Value = "(312) 555-0147",
+                        SortOrder = 2,
+                        IsVisible = false
+                    }
+                ],
+                SocialLinks =
+                [
+                    new PortfolioSocialLink
+                    {
+                        Platform = "github",
+                        Label = "GitHub",
+                        Url = "https://github.com/darkdhamon",
+                        SortOrder = 1,
+                        IsVisible = true
+                    }
+                ]
+            }
+        };
+
+        var controller = new PortfolioProfileController(repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+        controller.ControllerContext.HttpContext.Items[RequestIdContext.ItemKey] = "profile-id";
+
+        var actionResult = await controller.GetAsync(CancellationToken.None);
+        var okResult = actionResult.Result as OkObjectResult;
+        var response = okResult?.Value as PortfolioProfileResponse;
+
+        Assert.That(response, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(response!.RequestId, Is.EqualTo("profile-id"));
+            Assert.That(response.DisplayName, Is.EqualTo("Bronze Loft"));
+            Assert.That(response.ContactMethods.Select(contactMethod => contactMethod.Label), Is.EqualTo(new[] { "Email" }));
+            Assert.That(response.SocialLinks.Select(socialLink => socialLink.Label), Is.EqualTo(new[] { "GitHub" }));
+        });
+    }
+
+    [Test]
+    public async Task GetAsync_ReturnsNotFoundWhenNoPublicProfileExists()
+    {
+        var controller = new PortfolioProfileController(new StubPortfolioProfileRepository())
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        var actionResult = await controller.GetAsync(CancellationToken.None);
+        var notFoundResult = actionResult.Result as NotFoundObjectResult;
+        var response = notFoundResult?.Value as ApiErrorResponse;
+
+        Assert.That(notFoundResult, Is.Not.Null);
+        Assert.That(response?.Message, Is.EqualTo("The requested portfolio profile could not be found."));
+    }
+
+    private sealed class StubPortfolioProfileRepository : IPortfolioProfileRepository
+    {
+        public PortfolioProfile? Profile { get; set; }
+
+        public Task<PortfolioProfile?> GetPublicAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Profile);
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileControllerTests.cs
@@ -32,7 +32,6 @@ public sealed class PortfolioProfileControllerTests
                         Type = "email",
                         Label = "Email",
                         Value = "bronze@example.dev",
-                        Href = "mailto:bronze@example.dev",
                         SortOrder = 1,
                         IsVisible = true
                     },
@@ -47,6 +46,14 @@ public sealed class PortfolioProfileControllerTests
                 ],
                 SocialLinks =
                 [
+                    new PortfolioSocialLink
+                    {
+                        Platform = "bad-link",
+                        Label = "Bad Link",
+                        Url = "javascript:alert('xss')",
+                        SortOrder = 0,
+                        IsVisible = true
+                    },
                     new PortfolioSocialLink
                     {
                         Platform = "github",
@@ -78,6 +85,7 @@ public sealed class PortfolioProfileControllerTests
             Assert.That(response!.RequestId, Is.EqualTo("profile-id"));
             Assert.That(response.DisplayName, Is.EqualTo("Bronze Loft"));
             Assert.That(response.ContactMethods.Select(contactMethod => contactMethod.Label), Is.EqualTo(new[] { "Email" }));
+            Assert.That(response.ContactMethods[0].Href, Is.EqualTo("mailto:bronze@example.dev"));
             Assert.That(response.SocialLinks.Select(socialLink => socialLink.Label), Is.EqualTo(new[] { "GitHub" }));
         });
     }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileControllerTests.cs
@@ -7,6 +7,7 @@ using ProjectPortfolio2026.Server.Controllers;
 using ProjectPortfolio2026.Server.Domain.Portfolio;
 using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
 using ProjectPortfolio2026.Server.Repositories;
+using ProjectPortfolio2026.Server.Services.Interfaces;
 
 namespace ProjectPortfolio2026.Server.Tests;
 
@@ -66,7 +67,7 @@ public sealed class PortfolioProfileControllerTests
             }
         };
 
-        var controller = new PortfolioProfileController(repository)
+        var controller = new PortfolioProfileController(repository, new StubPortfolioLinkFormatter())
         {
             ControllerContext = new ControllerContext
             {
@@ -93,7 +94,7 @@ public sealed class PortfolioProfileControllerTests
     [Test]
     public async Task GetAsync_ReturnsNotFoundWhenNoPublicProfileExists()
     {
-        var controller = new PortfolioProfileController(new StubPortfolioProfileRepository())
+        var controller = new PortfolioProfileController(new StubPortfolioProfileRepository(), new StubPortfolioLinkFormatter())
         {
             ControllerContext = new ControllerContext
             {
@@ -116,6 +117,23 @@ public sealed class PortfolioProfileControllerTests
         public Task<PortfolioProfile?> GetPublicAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Profile);
+        }
+    }
+
+    private sealed class StubPortfolioLinkFormatter : IPortfolioLinkFormatter
+    {
+        public string? BuildContactMethodHref(PortfolioContactMethod contactMethod)
+        {
+            return contactMethod.Type.Equals("email", StringComparison.OrdinalIgnoreCase)
+                ? $"mailto:{contactMethod.Value}"
+                : contactMethod.Href;
+        }
+
+        public string? BuildSocialLinkUrl(PortfolioSocialLink socialLink)
+        {
+            return socialLink.Url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                ? socialLink.Url
+                : null;
         }
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileRepositoryTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileRepositoryTests.cs
@@ -10,7 +10,7 @@ namespace ProjectPortfolio2026.Server.Tests;
 public sealed class PortfolioProfileRepositoryTests
 {
     [Test]
-    public async Task GetPublicAsync_ReturnsOnlyPublicProfileWithLoadedCollections()
+    public async Task GetPublicAsync_ReturnsNewestPublicProfileWithLoadedCollections()
     {
         await using var dbContext = CreateDbContext();
         dbContext.PortfolioProfiles.AddRange(
@@ -20,6 +20,13 @@ public sealed class PortfolioProfileRepositoryTests
                 ContactHeadline = "Hidden",
                 ContactIntro = "Hidden intro",
                 IsPublic = false
+            },
+            new PortfolioProfile
+            {
+                DisplayName = "Older Public Profile",
+                ContactHeadline = "Older",
+                ContactIntro = "Older intro",
+                IsPublic = true
             },
             new PortfolioProfile
             {

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileRepositoryTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioProfileRepositoryTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Data;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Repositories;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class PortfolioProfileRepositoryTests
+{
+    [Test]
+    public async Task GetPublicAsync_ReturnsOnlyPublicProfileWithLoadedCollections()
+    {
+        await using var dbContext = CreateDbContext();
+        dbContext.PortfolioProfiles.AddRange(
+            new PortfolioProfile
+            {
+                DisplayName = "Hidden Profile",
+                ContactHeadline = "Hidden",
+                ContactIntro = "Hidden intro",
+                IsPublic = false
+            },
+            new PortfolioProfile
+            {
+                DisplayName = "Bronze Loft",
+                ContactHeadline = "Reach out",
+                ContactIntro = "Public intro",
+                IsPublic = true,
+                ContactMethods =
+                [
+                    new PortfolioContactMethod
+                    {
+                        Type = "email",
+                        Label = "Email",
+                        Value = "bronze@example.dev",
+                        SortOrder = 2,
+                        IsVisible = true
+                    }
+                ],
+                SocialLinks =
+                [
+                    new PortfolioSocialLink
+                    {
+                        Platform = "github",
+                        Label = "GitHub",
+                        Url = "https://github.com/darkdhamon",
+                        SortOrder = 1,
+                        IsVisible = true
+                    }
+                ]
+            });
+        await dbContext.SaveChangesAsync();
+
+        var repository = new PortfolioProfileRepository(dbContext);
+        var profile = await repository.GetPublicAsync();
+
+        Assert.That(profile, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(profile!.DisplayName, Is.EqualTo("Bronze Loft"));
+            Assert.That(profile.ContactMethods.Select(contactMethod => contactMethod.Label), Is.EqualTo(new[] { "Email" }));
+            Assert.That(profile.SocialLinks.Select(socialLink => socialLink.Label), Is.EqualTo(new[] { "GitHub" }));
+        });
+    }
+
+    private static PortfolioDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<PortfolioDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        return new PortfolioDbContext(options);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioSeedDataTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioSeedDataTests.cs
@@ -15,6 +15,10 @@ public sealed class PortfolioSeedDataTests
 
         await PortfolioSeedData.InitializeAsync(dbContext);
 
+        var profiles = await dbContext.PortfolioProfiles
+            .Include(profile => profile.ContactMethods)
+            .Include(profile => profile.SocialLinks)
+            .ToListAsync();
         var projects = await dbContext.Projects
             .Include(project => project.Screenshots)
             .Include(project => project.DeveloperRoles)
@@ -25,6 +29,10 @@ public sealed class PortfolioSeedDataTests
             .Include(project => project.Milestones)
             .ToListAsync();
 
+        Assert.That(profiles, Has.Count.EqualTo(1));
+        Assert.That(profiles[0].IsPublic, Is.True);
+        Assert.That(profiles[0].ContactMethods, Has.Count.EqualTo(3));
+        Assert.That(profiles[0].SocialLinks, Has.Count.EqualTo(3));
         Assert.That(projects, Has.Count.EqualTo(100));
         Assert.That(projects.All(project => project.Screenshots.Count >= 2), Is.True);
         Assert.That(projects.Single(project => project.Title == "Project Portfolio 2026").Screenshots, Has.Count.EqualTo(6));
@@ -47,6 +55,7 @@ public sealed class PortfolioSeedDataTests
         await PortfolioSeedData.InitializeAsync(dbContext);
 
         Assert.That(await dbContext.Projects.CountAsync(), Is.EqualTo(100));
+        Assert.That(await dbContext.PortfolioProfiles.CountAsync(), Is.EqualTo(1));
     }
 
     private static PortfolioDbContext CreateDbContext()

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Portfolio/PortfolioContactMethodResponse.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Portfolio/PortfolioContactMethodResponse.cs
@@ -1,0 +1,16 @@
+namespace ProjectPortfolio2026.Server.Contracts.Portfolio;
+
+public sealed class PortfolioContactMethodResponse
+{
+    public string Type { get; set; } = string.Empty;
+
+    public string Label { get; set; } = string.Empty;
+
+    public string Value { get; set; } = string.Empty;
+
+    public string? Href { get; set; }
+
+    public string? Note { get; set; }
+
+    public int SortOrder { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Portfolio/PortfolioProfileResponse.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Portfolio/PortfolioProfileResponse.cs
@@ -1,0 +1,22 @@
+namespace ProjectPortfolio2026.Server.Contracts.Portfolio;
+
+public sealed class PortfolioProfileResponse
+{
+    public string? RequestId { get; set; }
+
+    public int Id { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string ContactHeadline { get; set; } = string.Empty;
+
+    public string ContactIntro { get; set; } = string.Empty;
+
+    public string? AvailabilityHeadline { get; set; }
+
+    public string? AvailabilitySummary { get; set; }
+
+    public List<PortfolioContactMethodResponse> ContactMethods { get; set; } = [];
+
+    public List<PortfolioSocialLinkResponse> SocialLinks { get; set; } = [];
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Portfolio/PortfolioSocialLinkResponse.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Portfolio/PortfolioSocialLinkResponse.cs
@@ -1,0 +1,16 @@
+namespace ProjectPortfolio2026.Server.Contracts.Portfolio;
+
+public sealed class PortfolioSocialLinkResponse
+{
+    public string Platform { get; set; } = string.Empty;
+
+    public string Label { get; set; } = string.Empty;
+
+    public string Url { get; set; } = string.Empty;
+
+    public string? Handle { get; set; }
+
+    public string? Summary { get; set; }
+
+    public int SortOrder { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/PortfolioProfileController.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/PortfolioProfileController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Contracts.Portfolio;
+using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Mappers;
+using ProjectPortfolio2026.Server.Repositories;
+
+namespace ProjectPortfolio2026.Server.Controllers;
+
+[ApiController]
+[Route("api/portfolio-profile")]
+public sealed class PortfolioProfileController(IPortfolioProfileRepository portfolioProfileRepository) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType<PortfolioProfileResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiErrorResponse>(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PortfolioProfileResponse>> GetAsync(CancellationToken cancellationToken)
+    {
+        var profile = await portfolioProfileRepository.GetPublicAsync(cancellationToken);
+        if (profile is null)
+        {
+            return NotFound(new ApiErrorResponse { Message = "The requested portfolio profile could not be found." });
+        }
+
+        var requestId = HttpContext.Items[RequestIdContext.ItemKey] as string;
+        return Ok(profile.ToResponse(requestId));
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/PortfolioProfileController.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/PortfolioProfileController.cs
@@ -4,12 +4,15 @@ using ProjectPortfolio2026.Server.Contracts.Portfolio;
 using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
 using ProjectPortfolio2026.Server.Mappers;
 using ProjectPortfolio2026.Server.Repositories;
+using ProjectPortfolio2026.Server.Services.Interfaces;
 
 namespace ProjectPortfolio2026.Server.Controllers;
 
 [ApiController]
 [Route("api/portfolio-profile")]
-public sealed class PortfolioProfileController(IPortfolioProfileRepository portfolioProfileRepository) : ControllerBase
+public sealed class PortfolioProfileController(
+    IPortfolioProfileRepository portfolioProfileRepository,
+    IPortfolioLinkFormatter portfolioLinkFormatter) : ControllerBase
 {
     [HttpGet]
     [ProducesResponseType<PortfolioProfileResponse>(StatusCodes.Status200OK)]
@@ -23,6 +26,6 @@ public sealed class PortfolioProfileController(IPortfolioProfileRepository portf
         }
 
         var requestId = HttpContext.Items[RequestIdContext.ItemKey] as string;
-        return Ok(profile.ToResponse(requestId));
+        return Ok(profile.ToResponse(portfolioLinkFormatter, requestId));
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/PortfolioContactMethodConfiguration.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/PortfolioContactMethodConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Data.Configurations;
+
+public sealed class PortfolioContactMethodConfiguration : IEntityTypeConfiguration<PortfolioContactMethod>
+{
+    public void Configure(EntityTypeBuilder<PortfolioContactMethod> builder)
+    {
+        builder.ToTable("PortfolioContactMethods");
+
+        builder.Property(contactMethod => contactMethod.Type)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(contactMethod => contactMethod.Label)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(contactMethod => contactMethod.Value)
+            .IsRequired()
+            .HasMaxLength(250);
+
+        builder.Property(contactMethod => contactMethod.Href)
+            .HasMaxLength(500);
+
+        builder.Property(contactMethod => contactMethod.Note)
+            .HasMaxLength(500);
+
+        builder.Property(contactMethod => contactMethod.IsVisible)
+            .HasDefaultValue(true);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/PortfolioProfileConfiguration.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/PortfolioProfileConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Data.Configurations;
+
+public sealed class PortfolioProfileConfiguration : IEntityTypeConfiguration<PortfolioProfile>
+{
+    public void Configure(EntityTypeBuilder<PortfolioProfile> builder)
+    {
+        builder.ToTable("PortfolioProfiles");
+
+        builder.Property(profile => profile.DisplayName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(profile => profile.ContactHeadline)
+            .IsRequired()
+            .HasMaxLength(250);
+
+        builder.Property(profile => profile.ContactIntro)
+            .IsRequired();
+
+        builder.Property(profile => profile.AvailabilityHeadline)
+            .HasMaxLength(200);
+
+        builder.Property(profile => profile.AvailabilitySummary)
+            .HasMaxLength(500);
+
+        builder.Property(profile => profile.IsPublic)
+            .HasDefaultValue(false);
+
+        builder.HasMany(profile => profile.ContactMethods)
+            .WithOne(contactMethod => contactMethod.PortfolioProfile)
+            .HasForeignKey(contactMethod => contactMethod.PortfolioProfileId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(profile => profile.SocialLinks)
+            .WithOne(socialLink => socialLink.PortfolioProfile)
+            .HasForeignKey(socialLink => socialLink.PortfolioProfileId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/PortfolioSocialLinkConfiguration.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/PortfolioSocialLinkConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Data.Configurations;
+
+public sealed class PortfolioSocialLinkConfiguration : IEntityTypeConfiguration<PortfolioSocialLink>
+{
+    public void Configure(EntityTypeBuilder<PortfolioSocialLink> builder)
+    {
+        builder.ToTable("PortfolioSocialLinks");
+
+        builder.Property(socialLink => socialLink.Platform)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(socialLink => socialLink.Label)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(socialLink => socialLink.Url)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(socialLink => socialLink.Handle)
+            .HasMaxLength(150);
+
+        builder.Property(socialLink => socialLink.Summary)
+            .HasMaxLength(500);
+
+        builder.Property(socialLink => socialLink.IsVisible)
+            .HasDefaultValue(true);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/PortfolioDbContext.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/PortfolioDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using ProjectPortfolio2026.Server.Domain.Identity;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
 using ProjectPortfolio2026.Server.Domain.Projects;
 
 namespace ProjectPortfolio2026.Server.Data;
@@ -10,6 +11,12 @@ public sealed class PortfolioDbContext(DbContextOptions<PortfolioDbContext> opti
     : IdentityDbContext<ApplicationUser, IdentityRole, string>(options)
 {
     public DbSet<ApplicationUser> ApplicationUsers => Set<ApplicationUser>();
+
+    public DbSet<PortfolioProfile> PortfolioProfiles => Set<PortfolioProfile>();
+
+    public DbSet<PortfolioContactMethod> PortfolioContactMethods => Set<PortfolioContactMethod>();
+
+    public DbSet<PortfolioSocialLink> PortfolioSocialLinks => Set<PortfolioSocialLink>();
 
     public DbSet<Project> Projects => Set<Project>();
 

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/SeedData/PortfolioSeedData.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/SeedData/PortfolioSeedData.cs
@@ -47,7 +47,6 @@ public static class PortfolioSeedData
                     Type = "email",
                     Label = "Email",
                     Value = "bronze@example.dev",
-                    Href = "mailto:bronze@example.dev",
                     Note = "Best for interview requests, consulting inquiries, and longer-form conversations.",
                     SortOrder = 1,
                     IsVisible = true
@@ -57,7 +56,6 @@ public static class PortfolioSeedData
                     Type = "phone",
                     Label = "Phone",
                     Value = "(312) 555-0147",
-                    Href = "tel:+13125550147",
                     Note = "Available for scheduled calls on weekdays between 9 AM and 5 PM Central.",
                     SortOrder = 2,
                     IsVisible = true

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/SeedData/PortfolioSeedData.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/SeedData/PortfolioSeedData.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
 using ProjectPortfolio2026.Server.Domain.Projects;
 
 namespace ProjectPortfolio2026.Server.Data.SeedData;
@@ -7,14 +8,104 @@ public static class PortfolioSeedData
 {
     public static async Task InitializeAsync(PortfolioDbContext dbContext, CancellationToken cancellationToken = default)
     {
-        if (await dbContext.Projects.AnyAsync(cancellationToken))
+        var hasProjects = await dbContext.Projects.AnyAsync(cancellationToken);
+        var hasPortfolioProfile = await dbContext.PortfolioProfiles.AnyAsync(cancellationToken);
+
+        if (hasProjects && hasPortfolioProfile)
         {
             return;
         }
 
-        var projects = CreateProjects();
-        dbContext.Projects.AddRange(projects);
+        if (!hasPortfolioProfile)
+        {
+            dbContext.PortfolioProfiles.Add(CreatePortfolioProfile());
+        }
+
+        if (!hasProjects)
+        {
+            var projects = CreateProjects();
+            dbContext.Projects.AddRange(projects);
+        }
+
         await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static PortfolioProfile CreatePortfolioProfile()
+    {
+        return new PortfolioProfile
+        {
+            DisplayName = "Bronze Loft",
+            ContactHeadline = "Choose the contact path that fits the conversation you want to have.",
+            ContactIntro = "This portfolio frames outreach as a calm next step. Recruiters, collaborators, and hiring teams should be able to find the right channel quickly without sorting through hardcoded one-off content.",
+            AvailabilityHeadline = "Open to new opportunities",
+            AvailabilitySummary = "Focused on full-stack product engineering roles where API design, thoughtful UI, and maintainable delivery all matter.",
+            IsPublic = true,
+            ContactMethods =
+            [
+                new PortfolioContactMethod
+                {
+                    Type = "email",
+                    Label = "Email",
+                    Value = "bronze@example.dev",
+                    Href = "mailto:bronze@example.dev",
+                    Note = "Best for interview requests, consulting inquiries, and longer-form conversations.",
+                    SortOrder = 1,
+                    IsVisible = true
+                },
+                new PortfolioContactMethod
+                {
+                    Type = "phone",
+                    Label = "Phone",
+                    Value = "(312) 555-0147",
+                    Href = "tel:+13125550147",
+                    Note = "Available for scheduled calls on weekdays between 9 AM and 5 PM Central.",
+                    SortOrder = 2,
+                    IsVisible = true
+                },
+                new PortfolioContactMethod
+                {
+                    Type = "location",
+                    Label = "Location",
+                    Value = "Chicago, Illinois",
+                    Note = "Open to remote roles, hybrid collaboration, and select on-site visits.",
+                    SortOrder = 3,
+                    IsVisible = true
+                }
+            ],
+            SocialLinks =
+            [
+                new PortfolioSocialLink
+                {
+                    Platform = "github",
+                    Label = "GitHub",
+                    Url = "https://github.com/darkdhamon",
+                    Handle = "@darkdhamon",
+                    Summary = "Code samples, ongoing portfolio work, and implementation details.",
+                    SortOrder = 1,
+                    IsVisible = true
+                },
+                new PortfolioSocialLink
+                {
+                    Platform = "linkedin",
+                    Label = "LinkedIn",
+                    Url = "https://www.linkedin.com/in/bronze-loft",
+                    Handle = "Bronze Loft",
+                    Summary = "Professional background, role history, and recruiter-friendly context.",
+                    SortOrder = 2,
+                    IsVisible = true
+                },
+                new PortfolioSocialLink
+                {
+                    Platform = "calendly",
+                    Label = "Calendly",
+                    Url = "https://calendly.com/bronze-loft/portfolio-intro",
+                    Handle = "Schedule an intro",
+                    Summary = "A lightweight path for a first conversation without email back-and-forth.",
+                    SortOrder = 3,
+                    IsVisible = true
+                }
+            ]
+        };
     }
 
     private static List<Project> CreateProjects()

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/PortfolioContactMethod.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/PortfolioContactMethod.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectPortfolio2026.Server.Domain.Portfolio;
+
+public sealed class PortfolioContactMethod
+{
+    public int Id { get; set; }
+
+    public int PortfolioProfileId { get; set; }
+
+    public PortfolioProfile PortfolioProfile { get; set; } = null!;
+
+    [Required]
+    [MaxLength(50)]
+    public string Type { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string Label { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(250)]
+    public string Value { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Href { get; set; }
+
+    [MaxLength(500)]
+    public string? Note { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public bool IsVisible { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/PortfolioProfile.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/PortfolioProfile.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectPortfolio2026.Server.Domain.Portfolio;
+
+public sealed class PortfolioProfile
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(200)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(250)]
+    public string ContactHeadline { get; set; } = string.Empty;
+
+    [Required]
+    public string ContactIntro { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string? AvailabilityHeadline { get; set; }
+
+    [MaxLength(500)]
+    public string? AvailabilitySummary { get; set; }
+
+    public bool IsPublic { get; set; }
+
+    public List<PortfolioContactMethod> ContactMethods { get; set; } = [];
+
+    public List<PortfolioSocialLink> SocialLinks { get; set; } = [];
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/PortfolioSocialLink.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/PortfolioSocialLink.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectPortfolio2026.Server.Domain.Portfolio;
+
+public sealed class PortfolioSocialLink
+{
+    public int Id { get; set; }
+
+    public int PortfolioProfileId { get; set; }
+
+    public PortfolioProfile PortfolioProfile { get; set; } = null!;
+
+    [Required]
+    [MaxLength(50)]
+    public string Platform { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string Label { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(500)]
+    public string Url { get; set; } = string.Empty;
+
+    [MaxLength(150)]
+    public string? Handle { get; set; }
+
+    [MaxLength(500)]
+    public string? Summary { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public bool IsVisible { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/PortfolioProfileContractMapper.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/PortfolioProfileContractMapper.cs
@@ -1,3 +1,4 @@
+using System.Net.Mail;
 using ProjectPortfolio2026.Server.Contracts.Portfolio;
 using ProjectPortfolio2026.Server.Domain.Portfolio;
 
@@ -20,30 +21,134 @@ public static class PortfolioProfileContractMapper
                 .Where(contactMethod => contactMethod.IsVisible)
                 .OrderBy(contactMethod => contactMethod.SortOrder)
                 .ThenBy(contactMethod => contactMethod.Label)
-                .Select(contactMethod => new PortfolioContactMethodResponse
-                {
-                    Type = contactMethod.Type,
-                    Label = contactMethod.Label,
-                    Value = contactMethod.Value,
-                    Href = contactMethod.Href,
-                    Note = contactMethod.Note,
-                    SortOrder = contactMethod.SortOrder
-                })
+                .Select(ToContactMethodResponse)
+                .Where(response => response is not null)
+                .Select(response => response!)
                 .ToList(),
             SocialLinks = profile.SocialLinks
                 .Where(socialLink => socialLink.IsVisible)
                 .OrderBy(socialLink => socialLink.SortOrder)
                 .ThenBy(socialLink => socialLink.Label)
-                .Select(socialLink => new PortfolioSocialLinkResponse
-                {
-                    Platform = socialLink.Platform,
-                    Label = socialLink.Label,
-                    Url = socialLink.Url,
-                    Handle = socialLink.Handle,
-                    Summary = socialLink.Summary,
-                    SortOrder = socialLink.SortOrder
-                })
+                .Select(ToSocialLinkResponse)
+                .Where(response => response is not null)
+                .Select(response => response!)
                 .ToList()
         };
+    }
+
+    private static PortfolioContactMethodResponse? ToContactMethodResponse(PortfolioContactMethod contactMethod)
+    {
+        var href = BuildContactMethodHref(contactMethod);
+        return new PortfolioContactMethodResponse
+        {
+            Type = contactMethod.Type,
+            Label = contactMethod.Label,
+            Value = contactMethod.Value,
+            Href = href,
+            Note = contactMethod.Note,
+            SortOrder = contactMethod.SortOrder
+        };
+    }
+
+    private static PortfolioSocialLinkResponse? ToSocialLinkResponse(PortfolioSocialLink socialLink)
+    {
+        var url = SanitizeUrl(socialLink.Url, "http", "https");
+        if (url is null)
+        {
+            return null;
+        }
+
+        return new PortfolioSocialLinkResponse
+        {
+            Platform = socialLink.Platform,
+            Label = socialLink.Label,
+            Url = url,
+            Handle = socialLink.Handle,
+            Summary = socialLink.Summary,
+            SortOrder = socialLink.SortOrder
+        };
+    }
+
+    private static string? BuildContactMethodHref(PortfolioContactMethod contactMethod)
+    {
+        if (contactMethod.Type.Equals("email", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildMailToHref(contactMethod.Value);
+        }
+
+        if (contactMethod.Type.Equals("phone", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildTelephoneHref(contactMethod.Value);
+        }
+
+        return SanitizeUrl(contactMethod.Href, "http", "https");
+    }
+
+    private static string? BuildMailToHref(string value)
+    {
+        var trimmedValue = value.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedValue))
+        {
+            return null;
+        }
+
+        try
+        {
+            var mailAddress = new MailAddress(trimmedValue);
+            return mailAddress.Address.Equals(trimmedValue, StringComparison.OrdinalIgnoreCase)
+                ? $"mailto:{mailAddress.Address}"
+                : null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string? BuildTelephoneHref(string value)
+    {
+        var normalizedPhone = NormalizeTelephoneValue(value);
+        return string.IsNullOrWhiteSpace(normalizedPhone)
+            ? null
+            : $"tel:{normalizedPhone}";
+    }
+
+    private static string? NormalizeTelephoneValue(string value)
+    {
+        var trimmedValue = value.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedValue))
+        {
+            return null;
+        }
+
+        var characters = trimmedValue
+            .Where((character, index) => char.IsDigit(character) || (character == '+' && index == 0))
+            .ToArray();
+        if (characters.Length == 0)
+        {
+            return null;
+        }
+
+        var normalizedValue = new string(characters);
+        return normalizedValue.Any(char.IsDigit)
+            ? normalizedValue
+            : null;
+    }
+
+    private static string? SanitizeUrl(string? value, params string[] allowedSchemes)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        return allowedSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase)
+            ? uri.AbsoluteUri
+            : null;
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/PortfolioProfileContractMapper.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/PortfolioProfileContractMapper.cs
@@ -1,0 +1,49 @@
+using ProjectPortfolio2026.Server.Contracts.Portfolio;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Mappers;
+
+public static class PortfolioProfileContractMapper
+{
+    public static PortfolioProfileResponse ToResponse(this PortfolioProfile profile, string? requestId = null)
+    {
+        return new PortfolioProfileResponse
+        {
+            RequestId = requestId,
+            Id = profile.Id,
+            DisplayName = profile.DisplayName,
+            ContactHeadline = profile.ContactHeadline,
+            ContactIntro = profile.ContactIntro,
+            AvailabilityHeadline = profile.AvailabilityHeadline,
+            AvailabilitySummary = profile.AvailabilitySummary,
+            ContactMethods = profile.ContactMethods
+                .Where(contactMethod => contactMethod.IsVisible)
+                .OrderBy(contactMethod => contactMethod.SortOrder)
+                .ThenBy(contactMethod => contactMethod.Label)
+                .Select(contactMethod => new PortfolioContactMethodResponse
+                {
+                    Type = contactMethod.Type,
+                    Label = contactMethod.Label,
+                    Value = contactMethod.Value,
+                    Href = contactMethod.Href,
+                    Note = contactMethod.Note,
+                    SortOrder = contactMethod.SortOrder
+                })
+                .ToList(),
+            SocialLinks = profile.SocialLinks
+                .Where(socialLink => socialLink.IsVisible)
+                .OrderBy(socialLink => socialLink.SortOrder)
+                .ThenBy(socialLink => socialLink.Label)
+                .Select(socialLink => new PortfolioSocialLinkResponse
+                {
+                    Platform = socialLink.Platform,
+                    Label = socialLink.Label,
+                    Url = socialLink.Url,
+                    Handle = socialLink.Handle,
+                    Summary = socialLink.Summary,
+                    SortOrder = socialLink.SortOrder
+                })
+                .ToList()
+        };
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/PortfolioProfileContractMapper.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/PortfolioProfileContractMapper.cs
@@ -1,12 +1,15 @@
-using System.Net.Mail;
 using ProjectPortfolio2026.Server.Contracts.Portfolio;
 using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Services.Interfaces;
 
 namespace ProjectPortfolio2026.Server.Mappers;
 
 public static class PortfolioProfileContractMapper
 {
-    public static PortfolioProfileResponse ToResponse(this PortfolioProfile profile, string? requestId = null)
+    public static PortfolioProfileResponse ToResponse(
+        this PortfolioProfile profile,
+        IPortfolioLinkFormatter linkFormatter,
+        string? requestId = null)
     {
         return new PortfolioProfileResponse
         {
@@ -21,7 +24,7 @@ public static class PortfolioProfileContractMapper
                 .Where(contactMethod => contactMethod.IsVisible)
                 .OrderBy(contactMethod => contactMethod.SortOrder)
                 .ThenBy(contactMethod => contactMethod.Label)
-                .Select(ToContactMethodResponse)
+                .Select(contactMethod => ToContactMethodResponse(contactMethod, linkFormatter))
                 .Where(response => response is not null)
                 .Select(response => response!)
                 .ToList(),
@@ -29,16 +32,18 @@ public static class PortfolioProfileContractMapper
                 .Where(socialLink => socialLink.IsVisible)
                 .OrderBy(socialLink => socialLink.SortOrder)
                 .ThenBy(socialLink => socialLink.Label)
-                .Select(ToSocialLinkResponse)
+                .Select(socialLink => ToSocialLinkResponse(socialLink, linkFormatter))
                 .Where(response => response is not null)
                 .Select(response => response!)
                 .ToList()
         };
     }
 
-    private static PortfolioContactMethodResponse? ToContactMethodResponse(PortfolioContactMethod contactMethod)
+    private static PortfolioContactMethodResponse? ToContactMethodResponse(
+        PortfolioContactMethod contactMethod,
+        IPortfolioLinkFormatter linkFormatter)
     {
-        var href = BuildContactMethodHref(contactMethod);
+        var href = linkFormatter.BuildContactMethodHref(contactMethod);
         return new PortfolioContactMethodResponse
         {
             Type = contactMethod.Type,
@@ -50,9 +55,11 @@ public static class PortfolioProfileContractMapper
         };
     }
 
-    private static PortfolioSocialLinkResponse? ToSocialLinkResponse(PortfolioSocialLink socialLink)
+    private static PortfolioSocialLinkResponse? ToSocialLinkResponse(
+        PortfolioSocialLink socialLink,
+        IPortfolioLinkFormatter linkFormatter)
     {
-        var url = SanitizeUrl(socialLink.Url, "http", "https");
+        var url = linkFormatter.BuildSocialLinkUrl(socialLink);
         if (url is null)
         {
             return null;
@@ -67,88 +74,5 @@ public static class PortfolioProfileContractMapper
             Summary = socialLink.Summary,
             SortOrder = socialLink.SortOrder
         };
-    }
-
-    private static string? BuildContactMethodHref(PortfolioContactMethod contactMethod)
-    {
-        if (contactMethod.Type.Equals("email", StringComparison.OrdinalIgnoreCase))
-        {
-            return BuildMailToHref(contactMethod.Value);
-        }
-
-        if (contactMethod.Type.Equals("phone", StringComparison.OrdinalIgnoreCase))
-        {
-            return BuildTelephoneHref(contactMethod.Value);
-        }
-
-        return SanitizeUrl(contactMethod.Href, "http", "https");
-    }
-
-    private static string? BuildMailToHref(string value)
-    {
-        var trimmedValue = value.Trim();
-        if (string.IsNullOrWhiteSpace(trimmedValue))
-        {
-            return null;
-        }
-
-        try
-        {
-            var mailAddress = new MailAddress(trimmedValue);
-            return mailAddress.Address.Equals(trimmedValue, StringComparison.OrdinalIgnoreCase)
-                ? $"mailto:{mailAddress.Address}"
-                : null;
-        }
-        catch (FormatException)
-        {
-            return null;
-        }
-    }
-
-    private static string? BuildTelephoneHref(string value)
-    {
-        var normalizedPhone = NormalizeTelephoneValue(value);
-        return string.IsNullOrWhiteSpace(normalizedPhone)
-            ? null
-            : $"tel:{normalizedPhone}";
-    }
-
-    private static string? NormalizeTelephoneValue(string value)
-    {
-        var trimmedValue = value.Trim();
-        if (string.IsNullOrWhiteSpace(trimmedValue))
-        {
-            return null;
-        }
-
-        var characters = trimmedValue
-            .Where((character, index) => char.IsDigit(character) || (character == '+' && index == 0))
-            .ToArray();
-        if (characters.Length == 0)
-        {
-            return null;
-        }
-
-        var normalizedValue = new string(characters);
-        return normalizedValue.Any(char.IsDigit)
-            ? normalizedValue
-            : null;
-    }
-
-    private static string? SanitizeUrl(string? value, params string[] allowedSchemes)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri))
-        {
-            return null;
-        }
-
-        return allowedSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase)
-            ? uri.AbsoluteUri
-            : null;
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260408182642_AddPortfolioProfileData.Designer.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260408182642_AddPortfolioProfileData.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectPortfolio2026.Server.Data;
 
@@ -11,9 +12,11 @@ using ProjectPortfolio2026.Server.Data;
 namespace ProjectPortfolio2026.Server.Migrations
 {
     [DbContext(typeof(PortfolioDbContext))]
-    partial class PortfolioDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408182642_AddPortfolioProfileData")]
+    partial class AddPortfolioProfileData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260408182642_AddPortfolioProfileData.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260408182642_AddPortfolioProfileData.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectPortfolio2026.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPortfolioProfileData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PortfolioProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    DisplayName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ContactHeadline = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    ContactIntro = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AvailabilityHeadline = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AvailabilitySummary = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    IsPublic = table.Column<bool>(type: "bit", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PortfolioProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PortfolioContactMethods",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PortfolioProfileId = table.Column<int>(type: "int", nullable: false),
+                    Type = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    Href = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    Note = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    SortOrder = table.Column<int>(type: "int", nullable: false),
+                    IsVisible = table.Column<bool>(type: "bit", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PortfolioContactMethods", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PortfolioContactMethods_PortfolioProfiles_PortfolioProfileId",
+                        column: x => x.PortfolioProfileId,
+                        principalTable: "PortfolioProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PortfolioSocialLinks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PortfolioProfileId = table.Column<int>(type: "int", nullable: false),
+                    Platform = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Url = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    Handle = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: true),
+                    Summary = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    SortOrder = table.Column<int>(type: "int", nullable: false),
+                    IsVisible = table.Column<bool>(type: "bit", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PortfolioSocialLinks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PortfolioSocialLinks_PortfolioProfiles_PortfolioProfileId",
+                        column: x => x.PortfolioProfileId,
+                        principalTable: "PortfolioProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PortfolioContactMethods_PortfolioProfileId",
+                table: "PortfolioContactMethods",
+                column: "PortfolioProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PortfolioSocialLinks_PortfolioProfileId",
+                table: "PortfolioSocialLinks",
+                column: "PortfolioProfileId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PortfolioContactMethods");
+
+            migrationBuilder.DropTable(
+                name: "PortfolioSocialLinks");
+
+            migrationBuilder.DropTable(
+                name: "PortfolioProfiles");
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
@@ -70,6 +70,7 @@ builder.Services
         };
     });
 builder.Services.AddAuthorization();
+builder.Services.AddScoped<IPortfolioProfileRepository, PortfolioProfileRepository>();
 builder.Services.AddScoped<IProjectRepository, ProjectRepository>();
 builder.Services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
 builder.Services.AddScoped<IAuthService, AuthService>();

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
@@ -71,6 +71,7 @@ builder.Services
     });
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<IPortfolioProfileRepository, PortfolioProfileRepository>();
+builder.Services.AddScoped<IPortfolioLinkFormatter, PortfolioLinkFormatter>();
 builder.Services.AddScoped<IProjectRepository, ProjectRepository>();
 builder.Services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
 builder.Services.AddScoped<IAuthService, AuthService>();

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/IPortfolioProfileRepository.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/IPortfolioProfileRepository.cs
@@ -1,0 +1,8 @@
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Repositories;
+
+public interface IPortfolioProfileRepository
+{
+    Task<PortfolioProfile?> GetPublicAsync(CancellationToken cancellationToken = default);
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/PortfolioProfileRepository.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/PortfolioProfileRepository.cs
@@ -13,7 +13,7 @@ public sealed class PortfolioProfileRepository(PortfolioDbContext dbContext) : I
             .Include(profile => profile.ContactMethods)
             .Include(profile => profile.SocialLinks)
             .Where(profile => profile.IsPublic)
-            .OrderBy(profile => profile.Id)
-            .SingleOrDefaultAsync(cancellationToken);
+            .OrderByDescending(profile => profile.Id)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/PortfolioProfileRepository.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/PortfolioProfileRepository.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using ProjectPortfolio2026.Server.Data;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Repositories;
+
+public sealed class PortfolioProfileRepository(PortfolioDbContext dbContext) : IPortfolioProfileRepository
+{
+    public async Task<PortfolioProfile?> GetPublicAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.PortfolioProfiles
+            .AsNoTracking()
+            .Include(profile => profile.ContactMethods)
+            .Include(profile => profile.SocialLinks)
+            .Where(profile => profile.IsPublic)
+            .OrderBy(profile => profile.Id)
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/PortfolioLinkFormatter.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/PortfolioLinkFormatter.cs
@@ -1,0 +1,96 @@
+using System.Net.Mail;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Services.Interfaces;
+
+namespace ProjectPortfolio2026.Server.Services.Implementations;
+
+public sealed class PortfolioLinkFormatter : IPortfolioLinkFormatter
+{
+    public string? BuildContactMethodHref(PortfolioContactMethod contactMethod)
+    {
+        if (contactMethod.Type.Equals("email", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildMailToHref(contactMethod.Value);
+        }
+
+        if (contactMethod.Type.Equals("phone", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildTelephoneHref(contactMethod.Value);
+        }
+
+        return SanitizeUrl(contactMethod.Href, "http", "https");
+    }
+
+    public string? BuildSocialLinkUrl(PortfolioSocialLink socialLink)
+    {
+        return SanitizeUrl(socialLink.Url, "http", "https");
+    }
+
+    private static string? BuildMailToHref(string value)
+    {
+        var trimmedValue = value.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedValue))
+        {
+            return null;
+        }
+
+        try
+        {
+            var mailAddress = new MailAddress(trimmedValue);
+            return mailAddress.Address.Equals(trimmedValue, StringComparison.OrdinalIgnoreCase)
+                ? $"mailto:{mailAddress.Address}"
+                : null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string? BuildTelephoneHref(string value)
+    {
+        var normalizedPhone = NormalizeTelephoneValue(value);
+        return string.IsNullOrWhiteSpace(normalizedPhone)
+            ? null
+            : $"tel:{normalizedPhone}";
+    }
+
+    private static string? NormalizeTelephoneValue(string value)
+    {
+        var trimmedValue = value.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedValue))
+        {
+            return null;
+        }
+
+        var characters = trimmedValue
+            .Where((character, index) => char.IsDigit(character) || (character == '+' && index == 0))
+            .ToArray();
+        if (characters.Length == 0)
+        {
+            return null;
+        }
+
+        var normalizedValue = new string(characters);
+        return normalizedValue.Any(char.IsDigit)
+            ? normalizedValue
+            : null;
+    }
+
+    private static string? SanitizeUrl(string? value, params string[] allowedSchemes)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        return allowedSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase)
+            ? uri.AbsoluteUri
+            : null;
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IPortfolioLinkFormatter.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IPortfolioLinkFormatter.cs
@@ -1,0 +1,10 @@
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Services.Interfaces;
+
+public interface IPortfolioLinkFormatter
+{
+    string? BuildContactMethodHref(PortfolioContactMethod contactMethod);
+
+    string? BuildSocialLinkUrl(PortfolioSocialLink socialLink);
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1443,6 +1443,11 @@
     gap: 0.5rem;
 }
 
+.contact-panel h2 {
+    margin: 0;
+    color: #f4f8fe;
+}
+
 .contact-channel-list,
 .social-link-list,
 .contact-principles,
@@ -1472,6 +1477,10 @@
 .contact-channel-card a,
 .social-link-card strong {
     font-size: 1.1rem;
+}
+
+.contact-channel-card strong {
+    color: #f4f8fe;
 }
 
 .contact-channel-card p,

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -309,14 +309,11 @@
     padding-right: 2rem;
 }
 
-.home-page {
-    display: grid;
-    gap: 1.5rem;
-    padding: 2rem;
-}
-
+.home-page,
 .auth-page,
-.admin-page {
+.admin-page,
+.contact-page {
+    display: grid;
     gap: 1.5rem;
     padding: 2rem;
 }
@@ -458,7 +455,6 @@
 .admin-card p {
     margin: 0;
 }
-
 .site-header {
     grid-template-columns: minmax(0, 1fr) minmax(18rem, 30rem);
     gap: 1rem;
@@ -509,7 +505,8 @@
 
 .home-intro,
 .hero-panel,
-.detail-hero {
+.detail-hero,
+.contact-hero {
     position: relative;
     overflow: hidden;
     border: 1px solid rgba(35, 53, 88, 0.16);
@@ -548,6 +545,13 @@
     grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
     gap: 1.5rem;
     padding: 1.4rem;
+}
+
+.contact-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.3fr) minmax(18rem, 0.7fr);
+    gap: 1.25rem;
+    padding: 1.5rem;
 }
 
 .eyebrow {
@@ -620,6 +624,12 @@
     align-content: start;
 }
 
+.contact-hero-copy {
+    display: grid;
+    gap: 1rem;
+    align-content: start;
+}
+
 .detail-shell {
     gap: 1rem;
 }
@@ -676,6 +686,34 @@
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.12);
     backdrop-filter: blur(10px);
+}
+
+.contact-availability-card {
+    display: grid;
+    gap: 0.8rem;
+    align-content: start;
+    padding: 1.2rem;
+    border-radius: 1.25rem;
+    background:
+        linear-gradient(180deg, rgba(255, 248, 236, 0.96), rgba(245, 231, 197, 0.88)),
+        radial-gradient(circle at top right, rgba(16, 35, 61, 0.12), transparent 45%);
+    color: #10233d;
+    box-shadow: 0 20px 40px rgba(5, 12, 23, 0.2);
+}
+
+.contact-availability-card .stat-label {
+    color: rgba(16, 35, 61, 0.68);
+}
+
+.contact-availability-card strong {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    line-height: 1.05;
+}
+
+.contact-availability-card p {
+    margin: 0;
+    color: rgba(16, 35, 61, 0.82);
+    line-height: 1.7;
 }
 
 .stat-label,
@@ -1330,6 +1368,17 @@
     align-items: start;
 }
 
+.contact-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    align-items: start;
+}
+
+.contact-grid-secondary {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+}
+
 .detail-column {
     display: grid;
     gap: 1rem;
@@ -1359,6 +1408,104 @@
     box-shadow:
         0 20px 48px rgba(3, 10, 20, 0.24),
         inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.contact-panel {
+    display: grid;
+    gap: 1rem;
+    padding: 1.25rem;
+    border: 1px solid rgba(111, 137, 171, 0.16);
+    border-radius: 1.5rem;
+    background:
+        linear-gradient(180deg, rgba(13, 28, 48, 0.94), rgba(10, 23, 39, 0.92)),
+        radial-gradient(circle at top right, rgba(126, 233, 255, 0.08), transparent 42%);
+    box-shadow:
+        0 20px 48px rgba(3, 10, 20, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.contact-panel-emphasis {
+    background:
+        linear-gradient(180deg, rgba(20, 35, 58, 0.96), rgba(12, 24, 40, 0.94)),
+        radial-gradient(circle at top right, rgba(245, 183, 48, 0.12), transparent 42%);
+    border-color: rgba(245, 183, 48, 0.22);
+}
+
+.contact-panel-heading,
+.contact-channel-list,
+.social-link-list,
+.contact-principles,
+.contact-notes {
+    display: grid;
+}
+
+.contact-panel-heading {
+    gap: 0.5rem;
+}
+
+.contact-channel-list,
+.social-link-list,
+.contact-principles,
+.contact-notes {
+    gap: 0.85rem;
+}
+
+.contact-channel-card,
+.social-link-card,
+.principle-card {
+    display: grid;
+    gap: 0.45rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(111, 137, 171, 0.12);
+    background: rgba(255, 255, 255, 0.06);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.contact-channel-card a,
+.social-link-card {
+    color: #f4f8fe;
+    text-decoration: none;
+}
+
+.contact-channel-card strong,
+.contact-channel-card a,
+.social-link-card strong {
+    font-size: 1.1rem;
+}
+
+.contact-channel-card p,
+.social-link-card p,
+.principle-card p,
+.contact-notes p {
+    margin: 0;
+    color: rgba(226, 235, 246, 0.84);
+    line-height: 1.7;
+}
+
+.social-link-card {
+    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.social-link-card:hover {
+    transform: translateY(-1px);
+    border-color: rgba(245, 183, 48, 0.34);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.principle-card {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 0.8rem;
+}
+
+.principle-bullet {
+    width: 0.8rem;
+    height: 0.8rem;
+    margin-top: 0.35rem;
+    border-radius: 999px;
+    background: linear-gradient(180deg, #63deff 0%, #ffd77d 100%);
+    box-shadow: 0 0 0 0.25rem rgba(99, 222, 255, 0.08);
 }
 
 .detail-panel-wide {
@@ -1719,7 +1866,10 @@ h3 {
     .auth-card,
     .admin-hero,
     .project-card,
-    .detail-grid {
+    .detail-grid,
+    .contact-hero,
+    .contact-grid,
+    .contact-grid-secondary {
         grid-template-columns: 1fr;
     }
 
@@ -1797,7 +1947,9 @@ h3 {
     .hero-panel,
     .home-intro,
     .featured-panel,
-    .detail-hero {
+    .detail-hero,
+    .contact-hero,
+    .contact-panel {
         padding: 1.35rem;
     }
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -268,6 +268,27 @@ describe('App', () => {
         expect(fetchMock).toHaveBeenCalledWith('/api/projects?page=1&pageSize=6&requestId=request-1', expect.any(Object));
     });
 
+    it('renders the contact page mockup and highlights contact navigation', () => {
+        window.history.replaceState({}, '', '/contact');
+        fetchMock.mockResolvedValueOnce(jsonResponse({
+            isAuthenticated: false,
+            isAdmin: false,
+            username: null,
+            displayName: null,
+            email: null
+        }));
+
+        render(<App />);
+
+        expect(screen.getByRole('heading', { name: 'Choose the contact path that fits the conversation you want to have.' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('aria-current', 'page');
+        expect(screen.getByRole('link', { name: 'bronze@example.dev' })).toHaveAttribute('href', 'mailto:bronze@example.dev');
+        expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
+        expect(fetchMock).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({
+            method: 'GET'
+        }));
+    });
+
     it('shows loading and empty states for the list view', async () => {
         window.history.replaceState({}, '', '/projects');
         queueFetchJson(/^\/api\/projects\?/, {
@@ -931,6 +952,10 @@ describe('App helpers', () => {
             kind: 'detail',
             projectId: 42,
             listSearch: '?skills=React'
+        });
+
+        expect(parseRoute({ pathname: '/contact', search: '' })).toEqual({
+            kind: 'contact'
         });
     });
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -268,24 +268,76 @@ describe('App', () => {
         expect(fetchMock).toHaveBeenCalledWith('/api/projects?page=1&pageSize=6&requestId=request-1', expect.any(Object));
     });
 
-    it('renders the contact page mockup and highlights contact navigation', () => {
+    it('renders the contact page from the portfolio profile endpoint and highlights contact navigation', async () => {
         window.history.replaceState({}, '', '/contact');
-        fetchMock.mockResolvedValueOnce(jsonResponse({
-            isAuthenticated: false,
-            isAdmin: false,
-            username: null,
-            displayName: null,
-            email: null
-        }));
+        fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url === '/api/auth/me') {
+                return jsonResponse({
+                    isAuthenticated: false,
+                    isAdmin: false,
+                    username: null,
+                    displayName: null,
+                    email: null
+                });
+            }
+
+            if (url === '/api/portfolio-profile?requestId=request-1') {
+                return jsonResponse({
+                    requestId: 'request-1',
+                    id: 1,
+                    displayName: 'Bronze Loft',
+                    contactHeadline: 'Choose the contact path that fits the conversation you want to have.',
+                    contactIntro: 'This portfolio frames outreach as a calm next step.',
+                    availabilityHeadline: 'Open to new opportunities',
+                    availabilitySummary: 'Focused on full-stack product engineering roles.',
+                    contactMethods: [
+                        {
+                            type: 'email',
+                            label: 'Email',
+                            value: 'bronze@example.dev',
+                            href: 'mailto:bronze@example.dev',
+                            note: 'Best for interview requests.',
+                            sortOrder: 1
+                        },
+                        {
+                            type: 'location',
+                            label: 'Location',
+                            value: 'Chicago, Illinois',
+                            href: null,
+                            note: 'Open to remote roles.',
+                            sortOrder: 2
+                        }
+                    ],
+                    socialLinks: [
+                        {
+                            platform: 'github',
+                            label: 'GitHub',
+                            url: 'https://github.com/darkdhamon',
+                            handle: '@darkdhamon',
+                            summary: 'Code samples and implementation details.',
+                            sortOrder: 1
+                        }
+                    ]
+                });
+            }
+
+            throw new Error(`Unexpected fetch request: ${url}`);
+        });
 
         render(<App />);
 
-        expect(screen.getByRole('heading', { name: 'Choose the contact path that fits the conversation you want to have.' })).toBeInTheDocument();
+        expect(await screen.findByRole('heading', { name: 'Choose the contact path that fits the conversation you want to have.' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getByRole('link', { name: 'bronze@example.dev' })).toHaveAttribute('href', 'mailto:bronze@example.dev');
+        expect(screen.getByText('Chicago, Illinois')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
         expect(fetchMock).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({
             method: 'GET'
+        }));
+        expect(fetchMock).toHaveBeenCalledWith('/api/portfolio-profile?requestId=request-1', expect.objectContaining({
+            signal: expect.any(AbortSignal)
         }));
     });
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -331,8 +331,10 @@ describe('App', () => {
         expect(await screen.findByRole('heading', { name: 'Choose the contact path that fits the conversation you want to have.' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getByRole('link', { name: 'bronze@example.dev' })).toHaveAttribute('href', 'mailto:bronze@example.dev');
+        expect(screen.getByRole('link', { name: 'bronze@example.dev' })).toHaveAttribute('target', '_blank');
         expect(screen.getByText('Chicago, Illinois')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
+        expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('target', '_blank');
         expect(fetchMock).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({
             method: 'GET'
         }));

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
@@ -6,6 +6,7 @@ import { AdminDashboardPage } from './components/admin/AdminDashboardPage';
 import { LoginPage } from './components/admin/LoginPage';
 import { type AccountDraft } from './components/admin/mockAuth';
 import { SiteShell, type SiteShellContent } from './components/shell/SiteShell';
+import { ContactPage } from './features/contact/ContactPage';
 import { HomePage } from './features/home/HomePage';
 import { ProjectDetailPage } from './features/projects/ProjectDetailPage';
 import { ProjectListPage } from './features/projects/ProjectListPage';
@@ -50,7 +51,9 @@ function App() {
             ? 'Projects'
             : route.kind === 'login' || route.kind === 'admin' || route.kind === 'admin-account'
                 ? 'Admin'
-                : '';
+                : route.kind === 'contact'
+                    ? 'Contact'
+                    : '';
     const displayName = currentUser?.displayName.trim() ? currentUser.displayName.trim() : currentUser?.username ?? '';
     const shellContent = route.kind === 'home'
         ? {
@@ -82,11 +85,17 @@ function App() {
                             title: 'Account Settings',
                             summary: 'Update your username, email, display name, and password through the authenticated admin account flow.'
                         } satisfies SiteShellContent
-                        : {
-                            kicker: 'Project Portfolio',
-                            title: 'Projects',
-                            summary: 'Browse shipped work, search the portfolio, and move into individual project case studies.'
-                        } satisfies SiteShellContent;
+                        : route.kind === 'list'
+                            ? {
+                                kicker: 'Project Portfolio',
+                                title: 'Projects',
+                                summary: 'Browse shipped work, search the portfolio, and move into individual project case studies.'
+                            } satisfies SiteShellContent
+                            : {
+                                kicker: 'Project Portfolio',
+                                title: 'Contact',
+                                summary: 'Choose the right outreach channel, review availability, and move from portfolio browsing into a real conversation.'
+                            } satisfies SiteShellContent;
 
     const navigate: NavigateFn = (nextPath, options) => {
         const method = options?.replace ? 'replaceState' : 'pushState';
@@ -206,10 +215,12 @@ function App() {
                         </div>
                     </section>
                 </main>
-            ) : (
+            ) : route.kind === 'list' ? (
                 <ProjectListPage
                     filters={route.filters}
                     onNavigate={navigate} />
+            ) : (
+                <ContactPage />
             )}
         </SiteShell>
     );

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/app/types.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/app/types.ts
@@ -70,6 +70,36 @@ export interface FeaturedProjectsResponse {
     items: ProjectSummary[];
 }
 
+export interface PortfolioContactMethod {
+    type: string;
+    label: string;
+    value: string;
+    href?: string | null;
+    note?: string | null;
+    sortOrder: number;
+}
+
+export interface PortfolioSocialLink {
+    platform: string;
+    label: string;
+    url: string;
+    handle?: string | null;
+    summary?: string | null;
+    sortOrder: number;
+}
+
+export interface PortfolioProfile {
+    requestId?: string;
+    id: number;
+    displayName: string;
+    contactHeadline: string;
+    contactIntro: string;
+    availabilityHeadline?: string | null;
+    availabilitySummary?: string | null;
+    contactMethods: PortfolioContactMethod[];
+    socialLinks: PortfolioSocialLink[];
+}
+
 export interface ApiErrorResponse {
     message?: string;
 }

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/appSupport.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/appSupport.tsx
@@ -14,6 +14,7 @@ const adminRoutePattern = /^\/admin\/?$/;
 const adminAccountRoutePattern = /^\/admin\/account\/?$/;
 const listRoutePattern = /^\/projects\/?$/;
 const detailRoutePattern = /^\/projects\/(?<id>\d+)\/?$/;
+const contactRoutePattern = /^\/contact\/?$/;
 
 export function parseRoute(location: AppLocation) {
     if (homeRoutePattern.test(location.pathname)) {
@@ -54,6 +55,12 @@ export function parseRoute(location: AppLocation) {
         return {
             kind: 'list' as const,
             filters: parseListFilters(location.search)
+        };
+    }
+
+    if (contactRoutePattern.test(location.pathname)) {
+        return {
+            kind: 'contact' as const
         };
     }
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/shell/SiteShell.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/shell/SiteShell.tsx
@@ -22,7 +22,7 @@ const navItems: readonly NavItem[] = [
     { label: 'Timeline', description: 'Career milestones, education, and certifications.' },
     { label: 'About', description: 'Background, strengths, and developer story.' },
     { label: 'Resume', description: 'Resume hub and downloadable materials.' },
-    { label: 'Contact', description: 'Direct outreach paths and social links.' },
+    { label: 'Contact', href: '/contact', description: 'Direct outreach paths and social links.' },
     { label: 'Blog', description: 'Writing, updates, and thought pieces.' }
 ] as const;
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/contact/ContactPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/contact/ContactPage.tsx
@@ -1,0 +1,157 @@
+const contactChannels = [
+    {
+        label: 'Email',
+        value: 'bronze@example.dev',
+        href: 'mailto:bronze@example.dev',
+        note: 'Best for interview requests, consulting inquiries, and longer-form conversations.'
+    },
+    {
+        label: 'Phone',
+        value: '(312) 555-0147',
+        href: 'tel:+13125550147',
+        note: 'Available for scheduled calls on weekdays between 9 AM and 5 PM Central.'
+    },
+    {
+        label: 'Location',
+        value: 'Chicago, Illinois',
+        note: 'Open to remote roles, hybrid collaboration, and select on-site visits.'
+    }
+] as const;
+
+const socialLinks = [
+    {
+        label: 'GitHub',
+        href: 'https://github.com/darkdhamon',
+        handle: '@darkdhamon',
+        summary: 'Code samples, ongoing portfolio work, and implementation details.'
+    },
+    {
+        label: 'LinkedIn',
+        href: 'https://www.linkedin.com/in/bronze-loft',
+        handle: 'Bronze Loft',
+        summary: 'Professional background, role history, and recruiter-friendly context.'
+    },
+    {
+        label: 'Calendly',
+        href: 'https://calendly.com/bronze-loft/portfolio-intro',
+        handle: 'Schedule an intro',
+        summary: 'A lightweight path for a first conversation without email back-and-forth.'
+    }
+] as const;
+
+const responsePrinciples = [
+    'Clear communication on project scope, tradeoffs, and delivery progress.',
+    'Comfort across frontend, backend, and architecture-heavy problem spaces.',
+    'A preference for maintainable systems over one-off heroics.'
+] as const;
+
+export function ContactPage() {
+    return (
+        <main className="contact-page">
+            <section className="contact-hero">
+                <div className="contact-hero-copy">
+                    <p className="eyebrow">Direct Contact</p>
+                    <h1>Choose the contact path that fits the conversation you want to have.</h1>
+                    <p className="hero-description">
+                        This mockup frames outreach as a small, calm decision instead of a wall of links.
+                        Recruiters can move quickly, collaborators can find the right channel, and optional
+                        profile details can disappear cleanly when configuration is incomplete.
+                    </p>
+                </div>
+
+                <div className="contact-availability-card" aria-label="Current availability">
+                    <span className="stat-label">Current Availability</span>
+                    <strong>Open to new opportunities</strong>
+                    <p>
+                        Focused on full-stack product engineering roles where API design, thoughtful UI,
+                        and maintainable delivery all matter.
+                    </p>
+                </div>
+            </section>
+
+            <section className="contact-grid">
+                <article className="contact-panel">
+                    <div className="contact-panel-heading">
+                        <p className="eyebrow">Primary Channels</p>
+                        <h2>Reach out without guesswork.</h2>
+                    </div>
+
+                    <div className="contact-channel-list">
+                        {contactChannels.map(channel => (
+                            <section key={channel.label} className="contact-channel-card">
+                                <span className="meta-label">{channel.label}</span>
+                                {channel.href ? (
+                                    <a href={channel.href}>{channel.value}</a>
+                                ) : (
+                                    <strong>{channel.value}</strong>
+                                )}
+                                <p>{channel.note}</p>
+                            </section>
+                        ))}
+                    </div>
+                </article>
+
+                <article className="contact-panel contact-panel-emphasis">
+                    <div className="contact-panel-heading">
+                        <p className="eyebrow">Social Links</p>
+                        <h2>Profiles that reinforce the story.</h2>
+                    </div>
+
+                    <div className="social-link-list">
+                        {socialLinks.map(link => (
+                            <a
+                                key={link.label}
+                                className="social-link-card"
+                                href={link.href}
+                                target="_blank"
+                                rel="noreferrer">
+                                <div>
+                                    <span className="meta-label">{link.label}</span>
+                                    <strong>{link.handle}</strong>
+                                </div>
+                                <p>{link.summary}</p>
+                            </a>
+                        ))}
+                    </div>
+                </article>
+            </section>
+
+            <section className="contact-grid contact-grid-secondary">
+                <article className="contact-panel">
+                    <div className="contact-panel-heading">
+                        <p className="eyebrow">What To Expect</p>
+                        <h2>A portfolio contact page should answer more than “how.”</h2>
+                    </div>
+
+                    <div className="contact-principles">
+                        {responsePrinciples.map(principle => (
+                            <div key={principle} className="principle-card">
+                                <span className="principle-bullet" aria-hidden="true" />
+                                <p>{principle}</p>
+                            </div>
+                        ))}
+                    </div>
+                </article>
+
+                <article className="contact-panel">
+                    <div className="contact-panel-heading">
+                        <p className="eyebrow">Mockup Notes</p>
+                        <h2>Designed to become data-driven later.</h2>
+                    </div>
+
+                    <div className="contact-notes">
+                        <p>
+                            The card structure is intentionally friendly to future configuration work.
+                            Contact rows, social links, and availability text can all come from a single
+                            profile settings payload once the backend model exists.
+                        </p>
+                        <p>
+                            For now, this gives issue #6 a concrete visual direction without forcing the
+                            data model before the work history and resume issues are ready.
+                        </p>
+                    </div>
+                </article>
+            </section>
+        </main>
+    );
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/contact/ContactPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/contact/ContactPage.tsx
@@ -1,43 +1,4 @@
-const contactChannels = [
-    {
-        label: 'Email',
-        value: 'bronze@example.dev',
-        href: 'mailto:bronze@example.dev',
-        note: 'Best for interview requests, consulting inquiries, and longer-form conversations.'
-    },
-    {
-        label: 'Phone',
-        value: '(312) 555-0147',
-        href: 'tel:+13125550147',
-        note: 'Available for scheduled calls on weekdays between 9 AM and 5 PM Central.'
-    },
-    {
-        label: 'Location',
-        value: 'Chicago, Illinois',
-        note: 'Open to remote roles, hybrid collaboration, and select on-site visits.'
-    }
-] as const;
-
-const socialLinks = [
-    {
-        label: 'GitHub',
-        href: 'https://github.com/darkdhamon',
-        handle: '@darkdhamon',
-        summary: 'Code samples, ongoing portfolio work, and implementation details.'
-    },
-    {
-        label: 'LinkedIn',
-        href: 'https://www.linkedin.com/in/bronze-loft',
-        handle: 'Bronze Loft',
-        summary: 'Professional background, role history, and recruiter-friendly context.'
-    },
-    {
-        label: 'Calendly',
-        href: 'https://calendly.com/bronze-loft/portfolio-intro',
-        handle: 'Schedule an intro',
-        summary: 'A lightweight path for a first conversation without email back-and-forth.'
-    }
-] as const;
+import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
 
 const responsePrinciples = [
     'Clear communication on project scope, tradeoffs, and delivery progress.',
@@ -46,25 +7,32 @@ const responsePrinciples = [
 ] as const;
 
 export function ContactPage() {
+    const { profile, isLoading, error, isMissing } = usePortfolioProfile();
+    const contactMethods = profile?.contactMethods ?? [];
+    const socialLinks = profile?.socialLinks ?? [];
+
     return (
         <main className="contact-page">
+            {error ? <p className="status-banner error">{error}</p> : null}
+            {!error && isLoading ? <p className="status-banner">Loading contact profile...</p> : null}
+            {!error && !isLoading && isMissing ? (
+                <p className="status-banner">The public contact profile has not been configured yet.</p>
+            ) : null}
+
             <section className="contact-hero">
                 <div className="contact-hero-copy">
                     <p className="eyebrow">Direct Contact</p>
-                    <h1>Choose the contact path that fits the conversation you want to have.</h1>
+                    <h1>{profile?.contactHeadline ?? 'Choose the contact path that fits the conversation you want to have.'}</h1>
                     <p className="hero-description">
-                        This mockup frames outreach as a small, calm decision instead of a wall of links.
-                        Recruiters can move quickly, collaborators can find the right channel, and optional
-                        profile details can disappear cleanly when configuration is incomplete.
+                        {profile?.contactIntro ?? 'Contact details will appear here once the portfolio profile is available.'}
                     </p>
                 </div>
 
                 <div className="contact-availability-card" aria-label="Current availability">
                     <span className="stat-label">Current Availability</span>
-                    <strong>Open to new opportunities</strong>
+                    <strong>{profile?.availabilityHeadline ?? 'Availability not configured'}</strong>
                     <p>
-                        Focused on full-stack product engineering roles where API design, thoughtful UI,
-                        and maintainable delivery all matter.
+                        {profile?.availabilitySummary ?? 'Add a portfolio profile to publish an availability summary for the contact page.'}
                     </p>
                 </div>
             </section>
@@ -77,17 +45,21 @@ export function ContactPage() {
                     </div>
 
                     <div className="contact-channel-list">
-                        {contactChannels.map(channel => (
-                            <section key={channel.label} className="contact-channel-card">
-                                <span className="meta-label">{channel.label}</span>
-                                {channel.href ? (
-                                    <a href={channel.href}>{channel.value}</a>
+                        {contactMethods.length > 0 ? contactMethods.map(contactMethod => (
+                            <section
+                                key={`${contactMethod.type}-${contactMethod.label}-${contactMethod.sortOrder}`}
+                                className="contact-channel-card">
+                                <span className="meta-label">{contactMethod.label}</span>
+                                {contactMethod.href ? (
+                                    <a href={contactMethod.href}>{contactMethod.value}</a>
                                 ) : (
-                                    <strong>{channel.value}</strong>
+                                    <strong>{contactMethod.value}</strong>
                                 )}
-                                <p>{channel.note}</p>
+                                {contactMethod.note ? <p>{contactMethod.note}</p> : null}
                             </section>
-                        ))}
+                        )) : (
+                            <p className="secondary-copy">Public contact methods will appear here once they are configured.</p>
+                        )}
                     </div>
                 </article>
 
@@ -98,20 +70,22 @@ export function ContactPage() {
                     </div>
 
                     <div className="social-link-list">
-                        {socialLinks.map(link => (
+                        {socialLinks.length > 0 ? socialLinks.map(link => (
                             <a
-                                key={link.label}
+                                key={`${link.platform}-${link.label}-${link.sortOrder}`}
                                 className="social-link-card"
-                                href={link.href}
+                                href={link.url}
                                 target="_blank"
                                 rel="noreferrer">
                                 <div>
                                     <span className="meta-label">{link.label}</span>
-                                    <strong>{link.handle}</strong>
+                                    <strong>{link.handle ?? link.label}</strong>
                                 </div>
-                                <p>{link.summary}</p>
+                                {link.summary ? <p>{link.summary}</p> : null}
                             </a>
-                        ))}
+                        )) : (
+                            <p className="secondary-copy">Public social links will appear here once they are configured.</p>
+                        )}
                     </div>
                 </article>
             </section>
@@ -120,7 +94,7 @@ export function ContactPage() {
                 <article className="contact-panel">
                     <div className="contact-panel-heading">
                         <p className="eyebrow">What To Expect</p>
-                        <h2>A portfolio contact page should answer more than “how.”</h2>
+                        <h2>A portfolio contact page should answer more than "how."</h2>
                     </div>
 
                     <div className="contact-principles">
@@ -135,19 +109,18 @@ export function ContactPage() {
 
                 <article className="contact-panel">
                     <div className="contact-panel-heading">
-                        <p className="eyebrow">Mockup Notes</p>
-                        <h2>Designed to become data-driven later.</h2>
+                        <p className="eyebrow">Profile Model</p>
+                        <h2>Built around a portfolio profile aggregate.</h2>
                     </div>
 
                     <div className="contact-notes">
                         <p>
-                            The card structure is intentionally friendly to future configuration work.
-                            Contact rows, social links, and availability text can all come from a single
-                            profile settings payload once the backend model exists.
+                            Contact methods and social links are now loaded from the server through a
+                            portfolio profile entity instead of being hardcoded in the client.
                         </p>
                         <p>
-                            For now, this gives issue #6 a concrete visual direction without forcing the
-                            data model before the work history and resume issues are ready.
+                            Visibility is handled in the data model so the future admin experience can
+                            show or hide individual contact methods and platforms without changing the page layout.
                         </p>
                     </div>
                 </article>

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/contact/ContactPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/contact/ContactPage.tsx
@@ -51,7 +51,7 @@ export function ContactPage() {
                                 className="contact-channel-card">
                                 <span className="meta-label">{contactMethod.label}</span>
                                 {contactMethod.href ? (
-                                    <a href={contactMethod.href}>{contactMethod.value}</a>
+                                    <a href={contactMethod.href} target="_blank" rel="noreferrer">{contactMethod.value}</a>
                                 ) : (
                                     <strong>{contactMethod.value}</strong>
                                 )}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/hooks/usePortfolioProfile.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/hooks/usePortfolioProfile.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import {
+    fetchResponsePayloadWithStartupRetry,
+    RetryableApiError,
+    startupRetryMessage
+} from '../app/api';
+import type { PortfolioProfile } from '../app/types';
+
+interface UsePortfolioProfileResult {
+    profile: PortfolioProfile | null;
+    isLoading: boolean;
+    error: string | null;
+    isMissing: boolean;
+}
+
+export function usePortfolioProfile(): UsePortfolioProfileResult {
+    const [profile, setProfile] = useState<PortfolioProfile | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [isMissing, setIsMissing] = useState(false);
+
+    useEffect(() => {
+        const requestId = crypto.randomUUID();
+        const controller = new AbortController();
+
+        setIsLoading(true);
+        setError(null);
+        setIsMissing(false);
+
+        void loadProfile();
+
+        return () => controller.abort();
+
+        async function loadProfile() {
+            try {
+                const query = new URLSearchParams({ requestId });
+                const { response, payload } = await fetchResponsePayloadWithStartupRetry<PortfolioProfile>(
+                    `/api/portfolio-profile?${query.toString()}`,
+                    {
+                        signal: controller.signal
+                    },
+                    'Unable to load the contact profile right now.',
+                    [404]
+                );
+
+                if (response.status === 404) {
+                    setIsMissing(true);
+                    setProfile(null);
+                    return;
+                }
+
+                if (payload === null) {
+                    throw new RetryableApiError(startupRetryMessage);
+                }
+
+                const profileResponse = payload as PortfolioProfile;
+                if (profileResponse.requestId !== requestId) {
+                    return;
+                }
+
+                setProfile(profileResponse);
+            } catch (caughtError) {
+                if ((caughtError as Error).name === 'AbortError') {
+                    return;
+                }
+
+                setError(caughtError instanceof Error ? caughtError.message : 'Unable to load the contact profile right now.');
+                setProfile(null);
+            } finally {
+                setIsLoading(false);
+            }
+        }
+    }, []);
+
+    return {
+        profile,
+        isLoading,
+        error,
+        isMissing
+    };
+}

--- a/TODO.MD
+++ b/TODO.MD
@@ -1,12 +1,9 @@
 # TODO
 
 - Add out-of-scope ideas here for future follow-up.
-- Add delete support for projects.
-- Add search, filter, and query-specific repository methods for the future project list page.
 - Split admin and public project response shapes.
 - Add stronger project validation rules such as URL validation, date-range validation, and duplicate-tag normalization.
 - Add HTTP-level integration tests for the project API in addition to the current repository and controller tests.
-- Restrict unpublished project detail access for general users while preserving admin visibility once authentication and admin APIs are in place. The public `GET /api/projects/{id}` path should not expose draft or unpublished projects to anonymous users.
 - Ensure uploaded project images match the main display ratio of `2047:768`, and if an upload does not match, provide a user-controlled crop/position workflow before publishing.
 - Optimize the placeholder image assets for production so the fallback visuals keep their styling without carrying unnecessary bundle weight.
 - Evaluate and refine the public site's long-term color palette in a separate issue from dark-theme consistency work.


### PR DESCRIPTION
Closes #6

## Summary
- add a public `/contact` route, activate the contact navigation entry, and introduce the first contact page layout
- replace hardcoded contact content with a data-backed `PortfolioProfile` aggregate that includes profile details, contact methods, and social links
- expose a public portfolio profile API with repository, mapper, migration, and seeded development data for the contact page to consume
- update the contact experience to render dynamic contact methods and social links from the API response rather than fixed platform-specific markup
- generate `mailto:` and `tel:` links from stored contact values, allow only safe URL schemes for public links, and keep contact and social links opening in a new tab
- extract portfolio link generation and URL policy into a dedicated formatter service so the mapper stays focused on projection responsibilities
- load the newest public portfolio profile instead of assuming the database can only contain a single public row
- polish the contact page styling so the section headings and location text remain readable against the current theme
- merge the latest `dev` workflow updates and fix the CI changed-files step so PR prechecks can run without the PowerShell parser error

## Verification
- `dotnet test ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj`
- `npm test`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .github/scripts/run-dotnet-tests-with-coverage.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .github/scripts/run-client-tests-with-coverage.ps1`
- local PowerShell interpolation check for the fixed workflow log line
