### PR TITLE
Codex - Add CSRF protection for cookie-authenticated admin endpoints

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AuthAntiforgeryFlowTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AuthAntiforgeryFlowTests.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Contracts.Auth;
+using ProjectPortfolio2026.Server.Controllers;
+using ProjectPortfolio2026.Server.Infrastructure.Security;
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class AuthAntiforgeryFlowTests
+{
+    [Test]
+    public async Task ChangePasswordAsync_ReturnsBadRequest_WhenAntiforgeryTokenIsMissing()
+    {
+        await using var host = await CreateHostAsync();
+        using var client = host.GetTestClient();
+
+        var cookies = await GetIssuedCookiesAsync(client);
+        using var request = CreatePasswordChangeRequest(cookies);
+
+        var response = await client.SendAsync(request);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task ChangePasswordAsync_Succeeds_WhenAntiforgeryTokenIsProvided()
+    {
+        await using var host = await CreateHostAsync();
+        using var client = host.GetTestClient();
+
+        var cookies = await GetIssuedCookiesAsync(client);
+        var requestToken = ExtractCookieValue(cookies, AntiforgeryCookieManager.RequestTokenCookieName);
+        using var request = CreatePasswordChangeRequest(cookies);
+        request.Headers.Add(AntiforgeryCookieManager.HeaderName, requestToken);
+
+        var response = await client.SendAsync(request);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+    }
+
+    private static async Task<WebApplication> CreateHostAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddControllersWithViews().AddApplicationPart(typeof(AuthController).Assembly);
+        builder.Services.AddAntiforgery(options =>
+        {
+            options.HeaderName = AntiforgeryCookieManager.HeaderName;
+            options.Cookie.Name = "ProjectPortfolio2026.Antiforgery";
+            options.Cookie.HttpOnly = true;
+            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+        });
+        builder.Services
+            .AddAuthentication("Test")
+            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>("Test", _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddSingleton<IAuthService, StubAuthService>();
+
+        var app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.MapControllers();
+        await app.StartAsync();
+
+        return app;
+    }
+
+    private static async Task<string> GetIssuedCookiesAsync(HttpClient client)
+    {
+        var response = await client.GetAsync("/api/auth/me");
+        response.EnsureSuccessStatusCode();
+
+        return string.Join("; ", response.Headers.GetValues("Set-Cookie").Select(ParseCookieHeader));
+    }
+
+    private static HttpRequestMessage CreatePasswordChangeRequest(string cookies)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/me/password")
+        {
+            Content = new StringContent(
+                """
+                {"currentPassword":"old-password","newPassword":"Passw0rd!"}
+                """,
+                Encoding.UTF8,
+                "application/json")
+        };
+        request.Headers.Add("Cookie", cookies);
+        return request;
+    }
+
+    private static string ExtractCookieValue(string cookieHeader, string cookieName)
+    {
+        foreach (var cookiePart in cookieHeader.Split("; ", StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separatorIndex = cookiePart.IndexOf('=');
+            if (separatorIndex < 0)
+            {
+                continue;
+            }
+
+            var currentCookieName = cookiePart[..separatorIndex];
+            if (string.Equals(currentCookieName, cookieName, StringComparison.Ordinal))
+            {
+                return Uri.UnescapeDataString(cookiePart[(separatorIndex + 1)..]);
+            }
+        }
+
+        Assert.Fail($"Cookie '{cookieName}' was not issued.");
+        return string.Empty;
+    }
+
+    private static string ParseCookieHeader(string setCookieHeader)
+    {
+        var separatorIndex = setCookieHeader.IndexOf(';');
+        return separatorIndex >= 0 ? setCookieHeader[..separatorIndex] : setCookieHeader;
+    }
+
+    private sealed class StubAuthService : IAuthService
+    {
+        public Task<PasswordChangeResult> ChangePasswordAsync(
+            ClaimsPrincipal principal,
+            AccountPasswordChangeCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new PasswordChangeResult { Succeeded = true });
+        }
+
+        public Task<AuthStatusResponse> GetCurrentUserAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new AuthStatusResponse
+            {
+                IsAuthenticated = true,
+                IsAdmin = true,
+                UserName = "admin"
+            });
+        }
+
+        public Task<LoginResult> LoginAsync(AuthLoginCommand command, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new LoginResult
+            {
+                Succeeded = true,
+                User = new AuthStatusResponse
+                {
+                    IsAuthenticated = true,
+                    IsAdmin = true,
+                    UserName = "admin"
+                }
+            });
+        }
+
+        public Task SignOutAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<ProfileUpdateResult> UpdateCurrentUserAsync(
+            ClaimsPrincipal principal,
+            AccountProfileUpdateCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ProfileUpdateResult
+            {
+                Succeeded = true,
+                User = new AuthStatusResponse
+                {
+                    IsAuthenticated = true,
+                    IsAdmin = true,
+                    UserName = command.UserName
+                }
+            });
+        }
+    }
+
+    private sealed class TestAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.Name, "admin"),
+                    new Claim(ClaimTypes.Role, "portfolioAdmin")
+                ],
+                Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AuthControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AuthControllerTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using ProjectPortfolio2026.Server.Contracts.Auth;
 using ProjectPortfolio2026.Server.Controllers;
+using ProjectPortfolio2026.Server.Infrastructure.Security;
 using ProjectPortfolio2026.Server.Services.Interfaces;
 using ProjectPortfolio2026.Server.Services.ServiceModels;
 using System.Security.Claims;
@@ -19,7 +21,8 @@ public sealed class AuthControllerTests
         {
             LoginResult = new LoginResult { Succeeded = false }
         };
-        var controller = CreateController(authService);
+        var antiforgery = new StubAntiforgery();
+        var controller = CreateController(authService, antiforgery);
 
         var result = await controller.LoginAsync(
             new AuthLoginRequest
@@ -44,7 +47,8 @@ public sealed class AuthControllerTests
                 UserName = "admin"
             }
         };
-        var controller = CreateController(authService);
+        var antiforgery = new StubAntiforgery();
+        var controller = CreateController(authService, antiforgery);
 
         var result = await controller.GetCurrentUserAsync(CancellationToken.None);
         var okResult = result.Result as OkObjectResult;
@@ -56,6 +60,7 @@ public sealed class AuthControllerTests
             Assert.That(response!.IsAuthenticated, Is.True);
             Assert.That(response.IsAdmin, Is.True);
             Assert.That(response.UserName, Is.EqualTo("admin"));
+            Assert.That(antiforgery.GetAndStoreTokensCalls, Is.EqualTo(1));
         });
     }
 
@@ -70,7 +75,7 @@ public sealed class AuthControllerTests
                 UserNameConflict = true
             }
         };
-        var controller = CreateController(authService);
+        var controller = CreateController(authService, new StubAntiforgery());
 
         var result = await controller.UpdateCurrentUserAsync(
             new AccountProfileUpdateRequest
@@ -97,7 +102,7 @@ public sealed class AuthControllerTests
                 }
             }
         };
-        var controller = CreateController(authService);
+        var controller = CreateController(authService, new StubAntiforgery());
 
         var result = await controller.ChangePasswordAsync(
             new AccountPasswordChangeRequest
@@ -112,9 +117,54 @@ public sealed class AuthControllerTests
         Assert.That(objectResult?.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
     }
 
-    private static AuthController CreateController(IAuthService authService)
+    [Test]
+    public async Task LoginAsync_IssuesAntiforgeryToken_WhenCredentialsAreValid()
     {
-        return new AuthController(authService)
+        var authService = new StubAuthService
+        {
+            LoginResult = new LoginResult
+            {
+                Succeeded = true,
+                User = new AuthStatusResponse
+                {
+                    IsAuthenticated = true,
+                    IsAdmin = true,
+                    UserName = "admin"
+                }
+            }
+        };
+        var antiforgery = new StubAntiforgery();
+        var controller = CreateController(authService, antiforgery);
+
+        var result = await controller.LoginAsync(
+            new AuthLoginRequest
+            {
+                Login = "admin",
+                Password = "Passw0rd!"
+            },
+            CancellationToken.None);
+
+        var okResult = result.Result as OkObjectResult;
+        Assert.That(okResult?.Value, Is.InstanceOf<AuthStatusResponse>());
+        Assert.That(antiforgery.GetAndStoreTokensCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task LogoutAsync_DeletesRequestTokenCookie()
+    {
+        var controller = CreateController(new StubAuthService(), new StubAntiforgery());
+
+        var result = await controller.LogoutAsync();
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(
+            controller.HttpContext.Response.Headers.SetCookie.ToString(),
+            Does.Contain($"{AntiforgeryCookieManager.RequestTokenCookieName}=;"));
+    }
+
+    private static AuthController CreateController(IAuthService authService, IAntiforgery antiforgery)
+    {
+        return new AuthController(authService, antiforgery)
         {
             ControllerContext = new ControllerContext
             {
@@ -165,6 +215,37 @@ public sealed class AuthControllerTests
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(UpdateResult);
+        }
+    }
+
+    private sealed class StubAntiforgery : IAntiforgery
+    {
+        public int GetAndStoreTokensCalls { get; private set; }
+
+        public AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext)
+        {
+            GetAndStoreTokensCalls += 1;
+            return new AntiforgeryTokenSet("request-token", "cookie-token", AntiforgeryCookieManager.HeaderName, "ProjectPortfolio2026.Antiforgery");
+        }
+
+        public AntiforgeryTokenSet GetTokens(HttpContext httpContext)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> IsRequestValidAsync(HttpContext httpContext)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ValidateRequestAsync(HttpContext httpContext)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void SetCookieTokenAndHeader(HttpContext httpContext)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/AuthController.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/AuthController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using ProjectPortfolio2026.Server.Contracts.Auth;
+using ProjectPortfolio2026.Server.Infrastructure.Security;
 using ProjectPortfolio2026.Server.Services.Interfaces;
 using ProjectPortfolio2026.Server.Services.ServiceModels;
 
@@ -8,7 +10,7 @@ namespace ProjectPortfolio2026.Server.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public sealed class AuthController(IAuthService authService) : ControllerBase
+public sealed class AuthController(IAuthService authService, IAntiforgery antiforgery) : ControllerBase
 {
     [AllowAnonymous]
     [HttpPost("login")]
@@ -26,15 +28,18 @@ public sealed class AuthController(IAuthService authService) : ControllerBase
             },
             cancellationToken);
         return result.Succeeded && result.User is not null
-            ? Ok(result.User)
+            ? IssueAntiforgeryTokenAndReturn(result.User)
             : Unauthorized("Invalid username/email or password.");
     }
 
+    [Authorize]
+    [ValidateAntiForgeryToken]
     [HttpPost("logout")]
     [ProducesResponseType<LogoutResponse>(StatusCodes.Status200OK)]
     public async Task<ActionResult<LogoutResponse>> LogoutAsync()
     {
         await authService.SignOutAsync();
+        AntiforgeryCookieManager.DeleteRequestTokenCookie(HttpContext);
         return Ok(new LogoutResponse { SignedOut = true });
     }
 
@@ -44,10 +49,11 @@ public sealed class AuthController(IAuthService authService) : ControllerBase
     public async Task<ActionResult<AuthStatusResponse>> GetCurrentUserAsync(CancellationToken cancellationToken)
     {
         var response = await authService.GetCurrentUserAsync(User, cancellationToken);
-        return Ok(response);
+        return IssueAntiforgeryTokenAndReturn(response);
     }
 
     [Authorize]
+    [ValidateAntiForgeryToken]
     [HttpPut("me")]
     [ProducesResponseType<AuthStatusResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
@@ -66,7 +72,7 @@ public sealed class AuthController(IAuthService authService) : ControllerBase
             cancellationToken);
         if (result.Succeeded && result.User is not null)
         {
-            return Ok(result.User);
+            return IssueAntiforgeryTokenAndReturn(result.User);
         }
 
         if (result.UserNameConflict)
@@ -83,6 +89,7 @@ public sealed class AuthController(IAuthService authService) : ControllerBase
     }
 
     [Authorize]
+    [ValidateAntiForgeryToken]
     [HttpPost("me/password")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -109,5 +116,11 @@ public sealed class AuthController(IAuthService authService) : ControllerBase
         }
 
         return Unauthorized("Authentication is required.");
+    }
+
+    private OkObjectResult IssueAntiforgeryTokenAndReturn(AuthStatusResponse response)
+    {
+        AntiforgeryCookieManager.IssueRequestTokenCookie(HttpContext, antiforgery);
+        return Ok(response);
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Infrastructure/Security/AntiforgeryCookieManager.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Infrastructure/Security/AntiforgeryCookieManager.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Antiforgery;
+
+namespace ProjectPortfolio2026.Server.Infrastructure.Security;
+
+public static class AntiforgeryCookieManager
+{
+    public const string HeaderName = "X-XSRF-TOKEN";
+    public const string RequestTokenCookieName = "XSRF-TOKEN";
+
+    public static void IssueRequestTokenCookie(HttpContext context, IAntiforgery antiforgery)
+    {
+        var tokens = antiforgery.GetAndStoreTokens(context);
+        if (string.IsNullOrWhiteSpace(tokens.RequestToken))
+        {
+            return;
+        }
+
+        context.Response.Cookies.Append(
+            RequestTokenCookieName,
+            tokens.RequestToken,
+            new CookieOptions
+            {
+                HttpOnly = false,
+                IsEssential = true,
+                SameSite = SameSiteMode.Lax,
+                Secure = context.Request.IsHttps,
+                Path = "/"
+            });
+    }
+
+    public static void DeleteRequestTokenCookie(HttpContext context)
+    {
+        context.Response.Cookies.Delete(
+            RequestTokenCookieName,
+            new CookieOptions
+            {
+                Path = "/",
+                SameSite = SameSiteMode.Lax,
+                Secure = context.Request.IsHttps
+            });
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using ProjectPortfolio2026.Server.Data;
 using ProjectPortfolio2026.Server.Data.SeedData;
 using ProjectPortfolio2026.Server.Domain.Identity;
 using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Infrastructure.Security;
 using ProjectPortfolio2026.Server.Repositories;
 using ProjectPortfolio2026.Server.Services.Implementations;
 using ProjectPortfolio2026.Server.Services.Interfaces;
@@ -27,6 +29,14 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<RequestTrackingFilter>();
 });
 builder.Services.AddOpenApi();
+builder.Services.AddAntiforgery(options =>
+{
+    options.HeaderName = AntiforgeryCookieManager.HeaderName;
+    options.Cookie.Name = "ProjectPortfolio2026.Antiforgery";
+    options.Cookie.HttpOnly = true;
+    options.Cookie.SameSite = SameSiteMode.Lax;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+});
 builder.Services.AddDbContext<PortfolioDbContext>(options => options.UseSqlServer(resolvedConnectionString));
 builder.Services
     .AddIdentityCore<ApplicationUser>()
@@ -144,3 +154,5 @@ static async Task MigrateAndSeedAsync(IServiceProvider services, bool isDevelopm
         await DevelopmentIdentitySeedData.InitializeAsync(roleManager, userManager);
     }
 }
+
+public partial class Program;

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/api/http.test.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/api/http.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+    csrfHeaderName,
+    csrfCookieName,
     fetchAuthJson,
     fetchJsonWithStartupRetry,
     fetchResponsePayloadWithStartupRetry,
@@ -143,6 +145,7 @@ describe('http api helpers', () => {
 
     it('includes credentials and merged headers for auth requests', async () => {
         fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+        document.cookie = `${csrfCookieName}=csrf-token-value`;
 
         await fetchAuthJson(
             '/api/auth/me',
@@ -158,11 +161,31 @@ describe('http api helpers', () => {
         expect(fetchMock).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({
             credentials: 'include',
             method: 'POST',
-            headers: expect.objectContaining({
-                'Content-Type': 'application/json',
-                'X-Test': 'true'
-            })
+            headers: expect.any(Headers)
         }));
+
+        const [, options] = fetchMock.mock.calls[0];
+        const headers = options?.headers as Headers;
+        expect(headers.get('Content-Type')).toBe('application/json');
+        expect(headers.get('X-Test')).toBe('true');
+        expect(headers.get(csrfHeaderName)).toBe('csrf-token-value');
+    });
+
+    it('does not include the csrf header for safe auth requests', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+        document.cookie = `${csrfCookieName}=csrf-token-value`;
+
+        await fetchAuthJson(
+            '/api/auth/me',
+            {
+                method: 'GET'
+            },
+            'Fallback'
+        );
+
+        const [, options] = fetchMock.mock.calls[0];
+        const headers = options?.headers as Headers;
+        expect(headers.get(csrfHeaderName)).toBeNull();
     });
 
     it('throws the fallback error when an auth request fails without an api message', async () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/api/http.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/api/http.ts
@@ -3,6 +3,8 @@ export interface ApiErrorResponse {
 }
 
 export const startupRetryMessage = 'The portfolio API is still starting up. Please wait a moment and try again.';
+export const csrfHeaderName = 'X-XSRF-TOKEN';
+export const csrfCookieName = 'XSRF-TOKEN';
 const startupRetryDelayMs = 2000;
 const startupRetryAttempts = 2;
 
@@ -113,13 +115,18 @@ export async function fetchAuthJson<TPayload>(
     fallbackMessage: string,
     acceptedErrorStatuses: number[] = []
 ) {
+    const headers = new Headers(init.headers);
+    headers.set('Content-Type', 'application/json');
+
+    const csrfToken = shouldSendCsrfToken(init.method) ? readCookieValue(csrfCookieName) : null;
+    if (csrfToken) {
+        headers.set(csrfHeaderName, csrfToken);
+    }
+
     const response = await fetch(input, {
         credentials: 'include',
         ...init,
-        headers: {
-            'Content-Type': 'application/json',
-            ...(init.headers ?? {})
-        }
+        headers
     });
 
     const payload = await readResponsePayload<TPayload>(response);
@@ -130,4 +137,25 @@ export async function fetchAuthJson<TPayload>(
     }
 
     return { response, payload };
+}
+
+function shouldSendCsrfToken(method?: string) {
+    const normalizedMethod = (method ?? 'GET').toUpperCase();
+    return !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(normalizedMethod);
+}
+
+function readCookieValue(cookieName: string) {
+    if (typeof document === 'undefined' || !document.cookie) {
+        return null;
+    }
+
+    const encodedName = `${encodeURIComponent(cookieName)}=`;
+    for (const cookieEntry of document.cookie.split(';')) {
+        const trimmedEntry = cookieEntry.trim();
+        if (trimmedEntry.startsWith(encodedName)) {
+            return decodeURIComponent(trimmedEntry.slice(encodedName.length));
+        }
+    }
+
+    return null;
 }


### PR DESCRIPTION
Codex - Add CSRF protection for cookie-authenticated admin endpoints

Affected issues
- Closes #69

Summary of changes
- register ASP.NET Core antiforgery services and issue request tokens for the authenticated admin session flow
- require antiforgery validation on cookie-authenticated state-changing auth endpoints for logout, profile updates, and password changes
- update the React authenticated request helper to send the CSRF header automatically on mutation requests
- add server and client tests covering token issuance and protected mutation behavior

Validation
- dotnet test .\ProjectPortfolio2026\ProjectPortfolio2026.Server.Tests\ProjectPortfolio2026.Server.Tests.csproj
- npm test