### PR TITLE
Fix project board issue parsing for promotion PRs

### DIFF
--- a/.github/scripts/project-board-status.mjs
+++ b/.github/scripts/project-board-status.mjs
@@ -39,22 +39,20 @@ export function extractIssueNumbers(body) {
     sourceText = includedIssueLines.join("\n");
   }
 
+  return collectIssueNumbers(sourceText);
+}
+
+function collectIssueNumbers(sourceText) {
   const issueNumbers = new Set();
-  const genericIssuePattern = /#(\d+)\b/g;
+  const issueReferencePattern =
+    /(?:^|[\s(])(?:-\s*)?(?:(issues?)\s*:?\s*|(pull\s+request|pr)\s*:?\s*)?#(\d+)\b/gi;
 
-  for (const match of sourceText.matchAll(genericIssuePattern)) {
-    issueNumbers.add(Number(match[1]));
-  }
+  for (const match of sourceText.matchAll(issueReferencePattern)) {
+    if (match[2]) {
+      continue;
+    }
 
-  if (issueNumbers.size > 0) {
-    return [...issueNumbers];
-  }
-
-  const keywordPattern =
-    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|ref(?:er(?:s|enced?)?)?)\s*:?\s+#(\d+)\b/gi;
-
-  for (const match of body.matchAll(keywordPattern)) {
-    issueNumbers.add(Number(match[1]));
+    issueNumbers.add(Number(match[3]));
   }
 
   return [...issueNumbers];

--- a/.github/scripts/project-board-status.test.mjs
+++ b/.github/scripts/project-board-status.test.mjs
@@ -29,6 +29,28 @@ Fixes #70`;
   assert.deepEqual(extractIssueNumbers(body), [6, 33, 70]);
 });
 
+test("extractIssueNumbers ignores pull request references in prose", () => {
+  const body = `## Summary
+Promote dev to stage.
+
+## Included Issues
+- #69: add csrf protection
+
+## Release Notes
+- Includes Issue #69 via merged PR #81
+`;
+
+  assert.deepEqual(extractIssueNumbers(body), [69]);
+});
+
+test("extractIssueNumbers reads issue references outside Included Issues without capturing PR numbers", () => {
+  const body = `Issue #6 is ready for review.
+See #33 for follow-up work.
+Merged PR #70 already shipped separately.`;
+
+  assert.deepEqual(extractIssueNumbers(body), [6, 33]);
+});
+
 test("determineStatusName maps open PR activity to In review", () => {
   const pullRequest = {
     state: "open",


### PR DESCRIPTION
Codex - Fix project board issue parsing for promotion PRs

Affected issues
- Fixes the failing project board automation for promotion PRs by ignoring pull request references that are not repository issues

Summary of changes
- tighten linked issue parsing in `.github/scripts/project-board-status.mjs`
- ignore `PR #...` and `pull request #...` references so the automation only targets real issues
- add regression coverage for Included Issues parsing and promotion PR prose

Validation
- node --test .github/scripts/project-board-status.test.mjs