### PR TITLE
Codex - Add public resume page route and recruiter-focused layout

### DIFF
--- a/.github/scripts/project-board-status.mjs
+++ b/.github/scripts/project-board-status.mjs
@@ -14,14 +14,14 @@ const DEFAULT_CONFIG = {
   },
 };
 
-export function extractIssueNumbers(body) {
+export function extractIssueNumbers(body, repositoryFullName = null) {
   if (!body) {
     return [];
   }
 
   const issueNumbers = new Set([
     ...collectIncludedIssueNumbers(body),
-    ...collectClosingIssueNumbers(body),
+    ...collectClosingIssueNumbers(body, repositoryFullName),
   ]);
 
   return [...issueNumbers];
@@ -53,17 +53,28 @@ function collectIncludedIssueNumbers(body) {
   return collectDirectIssueNumbers(includedIssueLines.join("\n"));
 }
 
-function collectClosingIssueNumbers(sourceText) {
+function collectClosingIssueNumbers(sourceText, repositoryFullName) {
   const issueNumbers = new Set();
   const closingReferencePattern =
     /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*([^\r\n]+)/gi;
 
   for (const match of sourceText.matchAll(closingReferencePattern)) {
     const references = match[1] ?? "";
-    const issueReferencePattern = /(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)\b/g;
+    const issueReferencePattern =
+      /(?:(?<repository>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+))?#(?<issueNumber>\d+)\b/g;
 
     for (const issueMatch of references.matchAll(issueReferencePattern)) {
-      issueNumbers.add(Number(issueMatch[1]));
+      const referencedRepository = issueMatch.groups?.repository ?? null;
+
+      if (
+        referencedRepository &&
+        (!repositoryFullName ||
+          referencedRepository.toLowerCase() !== repositoryFullName.toLowerCase())
+      ) {
+        continue;
+      }
+
+      issueNumbers.add(Number(issueMatch.groups?.issueNumber));
     }
   }
 
@@ -270,7 +281,10 @@ export async function run({
     return;
   }
 
-  const issueNumbers = extractIssueNumbers(pullRequest?.body ?? "");
+  const issueNumbers = extractIssueNumbers(
+    pullRequest?.body ?? "",
+    `${owner}/${repo}`,
+  );
 
   if (issueNumbers.length === 0) {
     console.log(

--- a/.github/scripts/project-board-status.mjs
+++ b/.github/scripts/project-board-status.mjs
@@ -19,13 +19,44 @@ export function extractIssueNumbers(body) {
     return [];
   }
 
-  return collectClosingIssueNumbers(body);
+  const issueNumbers = new Set([
+    ...collectIncludedIssueNumbers(body),
+    ...collectClosingIssueNumbers(body),
+  ]);
+
+  return [...issueNumbers];
+}
+
+function collectIncludedIssueNumbers(body) {
+  const lines = body.split(/\r?\n/);
+  const includedIssuesHeaderIndex = lines.findIndex((line) =>
+    /^## Included Issues\b/.test(line),
+  );
+
+  if (includedIssuesHeaderIndex < 0) {
+    return [];
+  }
+
+  const includedIssueLines = [];
+  const includedIssueLinePattern = /^\s*(?:-\s*)?(?:issues?\s*:?\s*)?#\d+\b/i;
+
+  for (let index = includedIssuesHeaderIndex + 1; index < lines.length; index += 1) {
+    if (/^##\s/.test(lines[index])) {
+      break;
+    }
+
+    if (includedIssueLinePattern.test(lines[index])) {
+      includedIssueLines.push(lines[index]);
+    }
+  }
+
+  return collectDirectIssueNumbers(includedIssueLines.join("\n"));
 }
 
 function collectClosingIssueNumbers(sourceText) {
   const issueNumbers = new Set();
   const closingReferencePattern =
-    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*((?:(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+\b(?:\s*(?:,|and)\s*)?)*)/gi;
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*([^\r\n]+)/gi;
 
   for (const match of sourceText.matchAll(closingReferencePattern)) {
     const references = match[1] ?? "";
@@ -34,6 +65,22 @@ function collectClosingIssueNumbers(sourceText) {
     for (const issueMatch of references.matchAll(issueReferencePattern)) {
       issueNumbers.add(Number(issueMatch[1]));
     }
+  }
+
+  return [...issueNumbers];
+}
+
+function collectDirectIssueNumbers(sourceText) {
+  const issueNumbers = new Set();
+  const issueReferencePattern =
+    /(?:^|[\s(])(?:-\s*)?(?:(issues?)\s*:?\s*|(pull\s+request|pr)\s*:?\s*)?#(\d+)\b/gi;
+
+  for (const match of sourceText.matchAll(issueReferencePattern)) {
+    if (match[2]) {
+      continue;
+    }
+
+    issueNumbers.add(Number(match[3]));
   }
 
   return [...issueNumbers];

--- a/.github/scripts/project-board-status.mjs
+++ b/.github/scripts/project-board-status.mjs
@@ -19,40 +19,21 @@ export function extractIssueNumbers(body) {
     return [];
   }
 
-  const lines = body.split(/\r?\n/);
-  const includedIssuesHeaderIndex = lines.findIndex((line) =>
-    /^## Included Issues\b/.test(line),
-  );
-  let sourceText = body;
-
-  if (includedIssuesHeaderIndex >= 0) {
-    const includedIssueLines = [];
-
-    for (let index = includedIssuesHeaderIndex + 1; index < lines.length; index += 1) {
-      if (/^##\s/.test(lines[index])) {
-        break;
-      }
-
-      includedIssueLines.push(lines[index]);
-    }
-
-    sourceText = includedIssueLines.join("\n");
-  }
-
-  return collectIssueNumbers(sourceText);
+  return collectClosingIssueNumbers(body);
 }
 
-function collectIssueNumbers(sourceText) {
+function collectClosingIssueNumbers(sourceText) {
   const issueNumbers = new Set();
-  const issueReferencePattern =
-    /(?:^|[\s(])(?:-\s*)?(?:(issues?)\s*:?\s*|(pull\s+request|pr)\s*:?\s*)?#(\d+)\b/gi;
+  const closingReferencePattern =
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*((?:(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+\b(?:\s*(?:,|and)\s*)?)*)/gi;
 
-  for (const match of sourceText.matchAll(issueReferencePattern)) {
-    if (match[2]) {
-      continue;
+  for (const match of sourceText.matchAll(closingReferencePattern)) {
+    const references = match[1] ?? "";
+    const issueReferencePattern = /(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)\b/g;
+
+    for (const issueMatch of references.matchAll(issueReferencePattern)) {
+      issueNumbers.add(Number(issueMatch[1]));
     }
-
-    issueNumbers.add(Number(match[3]));
   }
 
   return [...issueNumbers];

--- a/.github/scripts/project-board-status.test.mjs
+++ b/.github/scripts/project-board-status.test.mjs
@@ -6,7 +6,7 @@ import {
   extractIssueNumbers,
 } from "./project-board-status.mjs";
 
-test("extractIssueNumbers reads only closing issue references", () => {
+test("extractIssueNumbers reads issue numbers from the Included Issues section", () => {
   const body = `## Summary
 Promote changes.
 
@@ -14,13 +14,11 @@ Promote changes.
 - #5: implement auth
 - #60: implement work history
 
-Closes #70
-
 ## Release Notes
 - references merged PR #74 for context
 `;
 
-  assert.deepEqual(extractIssueNumbers(body), [70]);
+  assert.deepEqual(extractIssueNumbers(body), [5, 60]);
 });
 
 test("extractIssueNumbers captures supported closing keywords only", () => {
@@ -42,7 +40,7 @@ Promote dev to stage.
 - Includes Issue #69 via merged PR #81
 `;
 
-  assert.deepEqual(extractIssueNumbers(body), []);
+  assert.deepEqual(extractIssueNumbers(body), [69]);
 });
 
 test("extractIssueNumbers ignores non-closing issue references", () => {
@@ -52,6 +50,16 @@ See #33 for follow-up work.
 Merged PR #70 already shipped separately.`;
 
   assert.deepEqual(extractIssueNumbers(body), []);
+});
+
+test("extractIssueNumbers merges Included Issues with closing references", () => {
+  const body = `## Included Issues
+- #12: promote shell changes
+
+Closes #85
+Related to #61`;
+
+  assert.deepEqual(extractIssueNumbers(body), [12, 85]);
 });
 
 test("extractIssueNumbers supports multiple closing references in one statement", () => {

--- a/.github/scripts/project-board-status.test.mjs
+++ b/.github/scripts/project-board-status.test.mjs
@@ -6,7 +6,7 @@ import {
   extractIssueNumbers,
 } from "./project-board-status.mjs";
 
-test("extractIssueNumbers reads issue numbers from the Included Issues section only", () => {
+test("extractIssueNumbers reads only closing issue references", () => {
   const body = `## Summary
 Promote changes.
 
@@ -14,19 +14,21 @@ Promote changes.
 - #5: implement auth
 - #60: implement work history
 
+Closes #70
+
 ## Release Notes
 - references merged PR #74 for context
 `;
 
-  assert.deepEqual(extractIssueNumbers(body), [5, 60]);
+  assert.deepEqual(extractIssueNumbers(body), [70]);
 });
 
-test("extractIssueNumbers falls back to generic references when no Included Issues section exists", () => {
+test("extractIssueNumbers captures supported closing keywords only", () => {
   const body = `Closes #6
 Refs #33
 Fixes #70`;
 
-  assert.deepEqual(extractIssueNumbers(body), [6, 33, 70]);
+  assert.deepEqual(extractIssueNumbers(body), [6, 70]);
 });
 
 test("extractIssueNumbers ignores pull request references in prose", () => {
@@ -40,15 +42,22 @@ Promote dev to stage.
 - Includes Issue #69 via merged PR #81
 `;
 
-  assert.deepEqual(extractIssueNumbers(body), [69]);
+  assert.deepEqual(extractIssueNumbers(body), []);
 });
 
-test("extractIssueNumbers reads issue references outside Included Issues without capturing PR numbers", () => {
-  const body = `Issue #6 is ready for review.
+test("extractIssueNumbers ignores non-closing issue references", () => {
+  const body = `Related to #61
+Issue #6 is ready for review.
 See #33 for follow-up work.
 Merged PR #70 already shipped separately.`;
 
-  assert.deepEqual(extractIssueNumbers(body), [6, 33]);
+  assert.deepEqual(extractIssueNumbers(body), []);
+});
+
+test("extractIssueNumbers supports multiple closing references in one statement", () => {
+  const body = `Resolves #12, #13 and owner/repo#14`;
+
+  assert.deepEqual(extractIssueNumbers(body), [12, 13, 14]);
 });
 
 test("determineStatusName maps open PR activity to In review", () => {

--- a/.github/scripts/project-board-status.test.mjs
+++ b/.github/scripts/project-board-status.test.mjs
@@ -63,9 +63,19 @@ Related to #61`;
 });
 
 test("extractIssueNumbers supports multiple closing references in one statement", () => {
-  const body = `Resolves #12, #13 and owner/repo#14`;
+  const body = `Resolves #12, #13 and darkdhamon/ProjectPortfolio2026#14`;
 
-  assert.deepEqual(extractIssueNumbers(body), [12, 13, 14]);
+  assert.deepEqual(extractIssueNumbers(body, "darkdhamon/ProjectPortfolio2026"), [
+    12,
+    13,
+    14,
+  ]);
+});
+
+test("extractIssueNumbers ignores cross-repo closing references", () => {
+  const body = `Resolves #12 and other-org/other-repo#14`;
+
+  assert.deepEqual(extractIssueNumbers(body, "darkdhamon/ProjectPortfolio2026"), [12]);
 });
 
 test("determineStatusName maps open PR activity to In review", () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -318,6 +318,185 @@
     padding: 2rem;
 }
 
+.resume-page,
+.resume-grid,
+.resume-panel,
+.resume-panel-heading,
+.resume-link-list,
+.resume-link-card,
+.resume-timeline,
+.resume-timeline-item,
+.resume-timeline-heading,
+.resume-action-area,
+.resume-action-grid,
+.resume-action-card,
+.resume-shell-note,
+.resume-hero,
+.resume-hero-copy,
+.resume-hero-meta {
+    display: grid;
+}
+
+.resume-page {
+    gap: 1.5rem;
+    padding: 2rem;
+}
+
+.resume-hero {
+    grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
+    gap: 1.5rem;
+    padding: 1.5rem;
+}
+
+.resume-hero-copy,
+.resume-hero-meta,
+.resume-panel,
+.resume-shell-note,
+.resume-link-card,
+.resume-action-card {
+    gap: 0.9rem;
+}
+
+.resume-hero-meta {
+    align-content: start;
+}
+
+.resume-callout-card,
+.resume-panel,
+.resume-link-card,
+.resume-timeline-item,
+.resume-action-card {
+    border: 1px solid rgba(111, 137, 171, 0.16);
+    border-radius: 1.3rem;
+    background:
+        linear-gradient(180deg, rgba(13, 29, 49, 0.88), rgba(9, 21, 36, 0.9)),
+        radial-gradient(circle at top right, rgba(99, 222, 255, 0.08), transparent 40%);
+    box-shadow: 0 18px 50px rgba(7, 16, 30, 0.18);
+}
+
+.resume-callout-card {
+    display: grid;
+    gap: 0.55rem;
+    padding: 1.1rem 1.15rem;
+    border-color: rgba(245, 183, 48, 0.2);
+    background:
+        linear-gradient(180deg, rgba(31, 48, 75, 0.92), rgba(14, 28, 47, 0.92)),
+        radial-gradient(circle at top right, rgba(245, 183, 48, 0.16), transparent 45%);
+}
+
+.resume-callout-card strong,
+.resume-panel h2,
+.resume-timeline-heading h3,
+.resume-action-card strong {
+    margin: 0;
+    color: #fff7e8;
+}
+
+.resume-callout-card strong {
+    font-size: 1.15rem;
+    line-height: 1.35;
+}
+
+.resume-callout-card p,
+.resume-link-card p,
+.resume-shell-note p,
+.resume-action-card p,
+.resume-date-range,
+.resume-timeline-heading p {
+    margin: 0;
+    color: rgba(219, 230, 243, 0.82);
+    line-height: 1.65;
+}
+
+.resume-grid {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.resume-grid-secondary {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+}
+
+.resume-panel {
+    gap: 1rem;
+    padding: 1.35rem;
+}
+
+.resume-panel-emphasis {
+    background:
+        linear-gradient(180deg, rgba(16, 34, 58, 0.94), rgba(11, 24, 41, 0.92)),
+        radial-gradient(circle at top right, rgba(245, 183, 48, 0.14), transparent 42%);
+}
+
+.resume-panel-heading {
+    gap: 0.35rem;
+}
+
+.resume-panel-heading .eyebrow {
+    margin-bottom: 0;
+}
+
+.resume-link-list,
+.resume-action-grid {
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    gap: 0.85rem;
+}
+
+.resume-link-card,
+.resume-action-card {
+    padding: 1rem;
+    text-decoration: none;
+}
+
+.resume-link-card strong {
+    color: #eff7ff;
+}
+
+.resume-link-card:hover {
+    transform: translateY(-1px);
+    border-color: rgba(126, 233, 255, 0.22);
+}
+
+.resume-shell-note {
+    min-height: 100%;
+    padding: 1rem 1.05rem;
+    border-radius: 1.1rem;
+    border: 1px dashed rgba(111, 137, 171, 0.22);
+    background: rgba(9, 21, 36, 0.42);
+}
+
+.resume-timeline {
+    gap: 0.85rem;
+}
+
+.resume-timeline-item {
+    gap: 0.75rem;
+    padding: 1rem 1.05rem;
+}
+
+.resume-timeline-heading {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.85rem;
+    align-items: start;
+}
+
+.resume-date-range {
+    justify-self: end;
+    white-space: nowrap;
+    font-size: 0.92rem;
+}
+
+.resume-action-area {
+    gap: 1rem;
+}
+
+.resume-action-panel {
+    background:
+        linear-gradient(180deg, rgba(17, 37, 63, 0.94), rgba(11, 23, 39, 0.92)),
+        radial-gradient(circle at top left, rgba(99, 222, 255, 0.12), transparent 38%);
+}
+
 .auth-page {
     align-content: start;
 }
@@ -1928,7 +2107,10 @@
     .contact-hero,
     .work-role-heading,
     .contact-grid,
-    .contact-grid-secondary {
+    .contact-grid-secondary,
+    .resume-grid,
+    .resume-grid-secondary,
+    .resume-hero {
         grid-template-columns: 1fr;
     }
 
@@ -1984,6 +2166,7 @@
     .site-header,
     .home-page,
     .portfolio-page,
+    .resume-page,
     .auth-page,
     .admin-page {
         padding: 1rem;
@@ -2008,12 +2191,27 @@
     .featured-panel,
     .detail-hero,
     .contact-hero,
+    .resume-hero,
     .contact-panel {
         padding: 1.35rem;
     }
 
     .hero-stats {
         grid-template-columns: 1fr;
+    }
+
+    .resume-link-list,
+    .resume-action-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .resume-timeline-heading {
+        grid-template-columns: 1fr;
+    }
+
+    .resume-date-range {
+        justify-self: start;
+        white-space: normal;
     }
 
     .toolbar,

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -330,6 +330,8 @@
 .resume-action-area,
 .resume-action-grid,
 .resume-action-card,
+.resume-action-button,
+.resume-action-copy,
 .resume-shell-note,
 .resume-hero,
 .resume-hero-copy,
@@ -439,14 +441,55 @@
 
 .resume-link-list,
 .resume-action-grid {
-    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
-    gap: 0.85rem;
+    grid-template-columns: repeat(auto-fit, minmax(11.5rem, 1fr));
+    gap: 0.7rem;
 }
 
 .resume-link-card,
 .resume-action-card {
     padding: 1rem;
     text-decoration: none;
+}
+
+.resume-action-card {
+    gap: 0.55rem;
+    padding: 0.75rem 0.8rem;
+}
+
+.resume-action-copy {
+    gap: 0.15rem;
+}
+
+.resume-action-note {
+    color: #f0d796;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.resume-action-copy .meta-label {
+    color: #d7e2f1;
+}
+
+.resume-action-button {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    min-height: 2.35rem;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid rgba(245, 183, 48, 0.18);
+    border-radius: 0.95rem;
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 247, 232, 0.76);
+    font-size: 0.88rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    cursor: not-allowed;
+}
+
+.resume-action-button:disabled {
+    opacity: 1;
 }
 
 .resume-link-card strong {
@@ -489,12 +532,20 @@
 
 .resume-action-area {
     gap: 1rem;
+    position: sticky;
+    top: 1rem;
+    z-index: 12;
 }
 
 .resume-action-panel {
+    gap: 0.85rem;
+    padding: 0.95rem 1rem;
     background:
         linear-gradient(180deg, rgba(17, 37, 63, 0.94), rgba(11, 23, 39, 0.92)),
         radial-gradient(circle at top left, rgba(99, 222, 255, 0.12), transparent 38%);
+    box-shadow:
+        0 18px 50px rgba(7, 16, 30, 0.24),
+        0 0 0 1px rgba(126, 233, 255, 0.04);
 }
 
 .auth-page {
@@ -2203,6 +2254,10 @@
     .resume-link-list,
     .resume-action-grid {
         grid-template-columns: 1fr;
+    }
+
+    .resume-action-area {
+        position: static;
     }
 
     .resume-timeline-heading {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -302,6 +302,88 @@ describe('App', () => {
         expect(fetchMock).toHaveBeenCalledWith('/api/work-history?requestId=request-1', expect.any(Object));
     });
 
+    it('renders the resume page route and highlights resume navigation', async () => {
+        window.history.replaceState({}, '', '/resume');
+        fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url === '/api/auth/me') {
+                return jsonResponse({
+                    isAuthenticated: false,
+                    isAdmin: false
+                });
+            }
+
+            if (url === '/api/portfolio-profile?requestId=request-1') {
+                return jsonResponse({
+                    requestId: 'request-1',
+                    id: 1,
+                    displayName: 'Bronze Loft',
+                    contactHeadline: 'Choose the contact path that fits the conversation you want to have.',
+                    contactIntro: 'Full-stack engineer focused on reliable delivery and clear communication.',
+                    availabilityHeadline: 'Open to senior full-stack roles',
+                    availabilitySummary: 'Remote-friendly and recruiter-ready.',
+                    contactMethods: [
+                        {
+                            type: 'email',
+                            label: 'Email',
+                            value: 'bronze@example.dev',
+                            href: 'mailto:bronze@example.dev',
+                            note: 'Best for interviews and hiring conversations.',
+                            sortOrder: 1
+                        }
+                    ],
+                    socialLinks: [
+                        {
+                            platform: 'github',
+                            label: 'GitHub',
+                            url: 'https://github.com/darkdhamon',
+                            handle: '@darkdhamon',
+                            summary: 'Public code samples and implementation details.',
+                            sortOrder: 1
+                        }
+                    ]
+                });
+            }
+
+            if (url === '/api/work-history?requestId=request-1') {
+                return jsonResponse({
+                    requestId: 'request-1',
+                    items: [
+                        {
+                            id: 7,
+                            name: 'Northwind Health',
+                            city: 'Chicago',
+                            region: 'IL',
+                            jobRoles: [
+                                {
+                                    role: 'Senior Software Engineer',
+                                    startDate: '2024-01-08',
+                                    endDate: null,
+                                    supervisorName: 'Dana Smith',
+                                    descriptionMarkdown: 'Leading API delivery.',
+                                    skills: ['API Design'],
+                                    technologies: ['.NET 10']
+                                }
+                            ]
+                        }
+                    ]
+                });
+            }
+
+            throw new Error(`Unexpected fetch request: ${url}`);
+        });
+
+        render(<App />);
+
+        expect(await screen.findByRole('heading', { name: 'Bronze Loft' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Resume' })).toHaveAttribute('aria-current', 'page');
+        expect(screen.getByText('Open to senior full-stack roles')).toBeInTheDocument();
+        expect(screen.getByText('Senior Software Engineer')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /bronze@example\.dev/i })).toHaveAttribute('href', 'mailto:bronze@example.dev');
+        expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
+    });
+
     it('renders the contact page from the portfolio profile endpoint and highlights contact navigation', async () => {
         window.history.replaceState({}, '', '/contact');
         fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
@@ -1010,7 +1092,7 @@ describe('App helpers', () => {
         });
     });
 
-    it('parses home, list, detail, and admin routes', () => {
+    it('parses home, list, detail, resume, and admin routes', () => {
         expect(parseRoute({ pathname: '/', search: '?search=react' })).toEqual({
             kind: 'home'
         });
@@ -1044,6 +1126,10 @@ describe('App helpers', () => {
 
         expect(parseRoute({ pathname: '/work-history', search: '' })).toEqual({
             kind: 'work-history'
+        });
+
+        expect(parseRoute({ pathname: '/resume', search: '' })).toEqual({
+            kind: 'resume'
         });
 
         expect(parseRoute({ pathname: '/contact', search: '' })).toEqual({

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -382,6 +382,10 @@ describe('App', () => {
         expect(screen.getByText('Senior Software Engineer')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /bronze@example\.dev/i })).toHaveAttribute('href', 'mailto:bronze@example.dev');
         expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
+        expect(screen.getByRole('button', { name: 'Filter Resume' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Highlight Skills' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Open Static Resume' })).toBeDisabled();
     });
 
     it('renders the contact page from the portfolio profile endpoint and highlights contact navigation', async () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
@@ -10,6 +10,7 @@ import { ContactPage } from './features/contact/ContactPage';
 import { HomePage } from './features/home/HomePage';
 import { ProjectDetailPage } from './features/projects/ProjectDetailPage';
 import { ProjectListPage } from './features/projects/ProjectListPage';
+import { ResumePage } from './features/resume/ResumePage';
 import { WorkHistoryPage } from './features/workHistory/WorkHistoryPage';
 import { useAuthSession } from './hooks/useAuthSession';
 import './App.css';
@@ -52,6 +53,8 @@ function App() {
             ? 'Projects'
             : route.kind === 'work-history'
                 ? 'Work History'
+            : route.kind === 'resume'
+                ? 'Resume'
             : route.kind === 'login' || route.kind === 'admin' || route.kind === 'admin-account'
                 ? 'Admin'
                 : route.kind === 'contact'
@@ -69,6 +72,12 @@ function App() {
                 kicker: 'Career Timeline',
                 title: 'Work History',
                 summary: 'Review employers, role progression, and the categorized skills and technologies connected to each chapter of the resume timeline.'
+            } satisfies SiteShellContent
+        : route.kind === 'resume'
+            ? {
+                kicker: 'Recruiter Snapshot',
+                title: 'Resume',
+                summary: 'Scan the candidate summary, contact signals, and structured work-history foundation in a format designed for fast recruiter review.'
             } satisfies SiteShellContent
         : route.kind === 'detail'
             ? {
@@ -185,6 +194,8 @@ function App() {
                 <HomePage onNavigate={navigate} />
             ) : route.kind === 'work-history' ? (
                 <WorkHistoryPage />
+            ) : route.kind === 'resume' ? (
+                <ResumePage />
             ) : route.kind === 'detail' ? (
                 <ProjectDetailPage
                     projectId={route.projectId}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/appSupport.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/appSupport.tsx
@@ -14,6 +14,7 @@ const adminRoutePattern = /^\/admin\/?$/;
 const adminAccountRoutePattern = /^\/admin\/account\/?$/;
 const listRoutePattern = /^\/projects\/?$/;
 const workHistoryRoutePattern = /^\/work-history\/?$/;
+const resumeRoutePattern = /^\/resume\/?$/;
 const detailRoutePattern = /^\/projects\/(?<id>\d+)\/?$/;
 const contactRoutePattern = /^\/contact\/?$/;
 
@@ -46,6 +47,12 @@ export function parseRoute(location: AppLocation) {
     if (workHistoryRoutePattern.test(location.pathname)) {
         return {
             kind: 'work-history' as const
+        };
+    }
+
+    if (resumeRoutePattern.test(location.pathname)) {
+        return {
+            kind: 'resume' as const
         };
     }
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/shell/SiteShell.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/shell/SiteShell.tsx
@@ -21,7 +21,7 @@ const navItems: readonly NavItem[] = [
     { label: 'Work History', href: '/work-history', description: 'Employers, roles, and resume-ready timeline data.' },
     { label: 'Admin', description: 'Authentication, dashboard access, and account management.' },
     { label: 'About', description: 'Background, strengths, and developer story.' },
-    { label: 'Resume', description: 'Resume hub and downloadable materials.' },
+    { label: 'Resume', href: '/resume', description: 'Recruiter-focused resume layout and career snapshot.' },
     { label: 'Contact', href: '/contact', description: 'Direct outreach paths and social links.' },
     { label: 'Blog', description: 'Writing, updates, and thought pieces.' }
 ] as const;

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -1,0 +1,235 @@
+import { formatProjectDates } from '../../appSupport';
+import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
+import { useWorkHistory } from '../../hooks/useWorkHistory';
+
+function getRoleCount(employerCount: number, roleCount: number) {
+    return `${roleCount} role${roleCount === 1 ? '' : 's'} across ${employerCount} employer${employerCount === 1 ? '' : 's'}`;
+}
+
+function getResumeContactHref(value: string) {
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+        return value;
+    }
+
+    if (value.includes('@')) {
+        return `mailto:${value}`;
+    }
+
+    return '';
+}
+
+export function ResumePage() {
+    const {
+        profile,
+        isLoading: isProfileLoading,
+        error: profileError,
+        isMissing: isProfileMissing
+    } = usePortfolioProfile();
+    const {
+        employers,
+        isLoading: isWorkHistoryLoading,
+        error: workHistoryError
+    } = useWorkHistory();
+
+    const roleCount = employers.reduce((total, employer) => total + employer.jobRoles.length, 0);
+    const location = employers
+        .map(employer => [employer.city, employer.region].filter(Boolean).join(', '))
+        .find(value => value.length > 0);
+    const primaryRole = employers.flatMap(employer => employer.jobRoles).find(role => role.role.trim().length > 0);
+    const contactMethods = (profile?.contactMethods ?? []).slice(0, 3);
+    const socialLinks = (profile?.socialLinks ?? []).slice(0, 2);
+    const sampleEmployers = employers.slice(0, 3);
+    const isLoading = isProfileLoading || isWorkHistoryLoading;
+    const errors = [profileError, workHistoryError].filter(Boolean);
+
+    return (
+        <main className="resume-page">
+            {errors.map(error => (
+                <p key={error} className="status-banner error">{error}</p>
+            ))}
+            {!errors.length && isLoading ? (
+                <p className="status-banner">Loading resume shell...</p>
+            ) : null}
+
+            <section className="hero-panel resume-hero">
+                <div className="resume-hero-copy">
+                    <p className="eyebrow">Public Resume</p>
+                    <h1>{profile?.displayName ?? 'Resume shell ready for public portfolio data.'}</h1>
+                    <p className="hero-description">
+                        {primaryRole?.role
+                            ? `${primaryRole.role}${location ? ` based in ${location}` : ''}. This recruiter-focused view is built to stay concise, skimmable, and ready for richer structured sections.`
+                            : 'This page establishes the recruiter-focused resume shell so structured sections, filtering, and export actions can plug in without reworking the layout.'}
+                    </p>
+                </div>
+
+                <div className="resume-hero-meta">
+                    <section className="resume-callout-card" aria-label="Resume summary">
+                        <span className="stat-label">Resume Snapshot</span>
+                        <strong>{roleCount > 0 ? getRoleCount(employers.length, roleCount) : 'Waiting for published resume data'}</strong>
+                        <p>
+                            {profile?.availabilityHeadline
+                                ? profile.availabilityHeadline
+                                : 'Publish public profile and work history records to turn this shell into a complete recruiter-facing resume.'}
+                        </p>
+                    </section>
+
+                    <div className="hero-stats" aria-label="Resume summary stats">
+                        <div className="stat-card">
+                            <span className="stat-label">Employers</span>
+                            <strong>{employers.length}</strong>
+                        </div>
+                        <div className="stat-card">
+                            <span className="stat-label">Roles</span>
+                            <strong>{roleCount}</strong>
+                        </div>
+                        <div className="stat-card">
+                            <span className="stat-label">Contact Channels</span>
+                            <strong>{contactMethods.length + socialLinks.length}</strong>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="resume-grid">
+                <article className="resume-panel resume-panel-emphasis">
+                    <div className="resume-panel-heading">
+                        <p className="eyebrow">Header</p>
+                        <h2>Recruiter essentials up front.</h2>
+                    </div>
+
+                    {contactMethods.length > 0 || socialLinks.length > 0 ? (
+                        <div className="resume-link-list">
+                            {contactMethods.map(method => {
+                                const href = method.href ?? getResumeContactHref(method.value);
+                                return href ? (
+                                    <a
+                                        key={`${method.type}-${method.label}-${method.sortOrder}`}
+                                        className="resume-link-card"
+                                        href={href}
+                                        target="_blank"
+                                        rel="noreferrer">
+                                        <span className="meta-label">{method.label}</span>
+                                        <strong>{method.value}</strong>
+                                        {method.note ? <p>{method.note}</p> : null}
+                                    </a>
+                                ) : (
+                                    <div key={`${method.type}-${method.label}-${method.sortOrder}`} className="resume-link-card">
+                                        <span className="meta-label">{method.label}</span>
+                                        <strong>{method.value}</strong>
+                                        {method.note ? <p>{method.note}</p> : null}
+                                    </div>
+                                );
+                            })}
+
+                            {socialLinks.map(link => (
+                                <a
+                                    key={`${link.platform}-${link.label}-${link.sortOrder}`}
+                                    className="resume-link-card"
+                                    href={link.url}
+                                    target="_blank"
+                                    rel="noreferrer">
+                                    <span className="meta-label">{link.label}</span>
+                                    <strong>{link.handle ?? link.label}</strong>
+                                    {link.summary ? <p>{link.summary}</p> : null}
+                                </a>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="secondary-copy">
+                            Public contact and social links will appear here once the portfolio profile is configured.
+                        </p>
+                    )}
+                </article>
+
+                <article className="resume-panel">
+                    <div className="resume-panel-heading">
+                        <p className="eyebrow">Profile Section</p>
+                        <h2>Summary area reserved for concise positioning.</h2>
+                    </div>
+
+                    <div className="resume-shell-note">
+                        <p>
+                            {profile?.contactIntro
+                                ? profile.contactIntro
+                                : 'A short recruiter-facing profile summary will land here once the public portfolio profile is ready for resume presentation.'}
+                        </p>
+                    </div>
+                </article>
+            </section>
+
+            <section className="resume-grid resume-grid-secondary">
+                <article className="resume-panel">
+                    <div className="resume-panel-heading">
+                        <p className="eyebrow">Experience Shell</p>
+                        <h2>Space reserved for condensed role history.</h2>
+                    </div>
+
+                    {sampleEmployers.length > 0 ? (
+                        <div className="resume-timeline">
+                            {sampleEmployers.map(employer => {
+                                const latestRole = employer.jobRoles[0];
+                                return (
+                                    <section key={employer.id} className="resume-timeline-item">
+                                        <div className="resume-timeline-heading">
+                                            <div>
+                                                <h3>{employer.name}</h3>
+                                                <p>{latestRole?.role ?? 'Published role details will appear here.'}</p>
+                                            </div>
+                                            {latestRole ? (
+                                                <span className="resume-date-range">
+                                                    {formatProjectDates(latestRole.startDate, latestRole.endDate)}
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                        <p className="helper-copy">
+                                            Full recruiter-focused role bullets, skill highlights, and optional sections are intentionally deferred to the next resume issue.
+                                        </p>
+                                    </section>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <p className="secondary-copy">
+                            Published work history will appear here once employer and job-role records are available.
+                        </p>
+                    )}
+                </article>
+
+                <article className="resume-panel">
+                    <div className="resume-panel-heading">
+                        <p className="eyebrow">Skills Shell</p>
+                        <h2>Reserved for scan-friendly capability highlights.</h2>
+                    </div>
+
+                    <div className="resume-shell-note">
+                        <p>
+                            Skill and technology emphasis will plug into this panel after the richer structured resume rendering work is complete.
+                        </p>
+                    </div>
+                </article>
+            </section>
+
+            <section className="resume-action-area">
+                <article className="resume-panel resume-action-panel">
+                    <div className="resume-panel-heading">
+                        <p className="eyebrow">Action Area</p>
+                        <h2>Future actions already have a home.</h2>
+                    </div>
+
+                    <div className="resume-action-grid">
+                        <div className="resume-action-card">
+                            <span className="meta-label">PDF Export</span>
+                            <strong>Planned under issue #88</strong>
+                            <p>An ATS-friendly export action will attach to this shell without changing the page structure.</p>
+                        </div>
+                        <div className="resume-action-card">
+                            <span className="meta-label">Static Resume Link</span>
+                            <strong>{isProfileMissing ? 'Not configured' : 'Awaiting configuration support'}</strong>
+                            <p>Optional external resume delivery will surface here once the admin configuration work is available.</p>
+                        </div>
+                    </div>
+                </article>
+            </section>
+        </main>
+    );
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -90,6 +90,74 @@ export function ResumePage() {
                 </div>
             </section>
 
+            <section className="resume-action-area">
+                <article className="resume-panel resume-action-panel">
+                    <p className="eyebrow">Resume Actions</p>
+                    <div className="resume-action-grid">
+                        <div className="resume-action-card">
+                            <div className="resume-action-copy">
+                                <span className="meta-label">Resume Filters</span>
+                                <span className="resume-action-note">Issue #87</span>
+                            </div>
+                            <button
+                                className="resume-action-button"
+                                type="button"
+                                disabled
+                                aria-disabled="true"
+                                aria-label="Filter Resume">
+                                <span>Filter Resume</span>
+                                <span className="coming-soon-pill">Coming Soon</span>
+                            </button>
+                        </div>
+                        <div className="resume-action-card">
+                            <div className="resume-action-copy">
+                                <span className="meta-label">Skill Highlights</span>
+                                <span className="resume-action-note">Issue #87</span>
+                            </div>
+                            <button
+                                className="resume-action-button"
+                                type="button"
+                                disabled
+                                aria-disabled="true"
+                                aria-label="Highlight Skills">
+                                <span>Highlight Skills</span>
+                                <span className="coming-soon-pill">Coming Soon</span>
+                            </button>
+                        </div>
+                        <div className="resume-action-card">
+                            <div className="resume-action-copy">
+                                <span className="meta-label">PDF Export</span>
+                                <span className="resume-action-note">Issue #88</span>
+                            </div>
+                            <button
+                                className="resume-action-button"
+                                type="button"
+                                disabled
+                                aria-disabled="true"
+                                aria-label="Download PDF">
+                                <span>Download PDF</span>
+                                <span className="coming-soon-pill">Coming Soon</span>
+                            </button>
+                        </div>
+                        <div className="resume-action-card">
+                            <div className="resume-action-copy">
+                                <span className="meta-label">Static Resume Link</span>
+                                <span className="resume-action-note">{isProfileMissing ? 'Needs config' : 'Planned'}</span>
+                            </div>
+                            <button
+                                className="resume-action-button"
+                                type="button"
+                                disabled
+                                aria-disabled="true"
+                                aria-label="Open Static Resume">
+                                <span>Open Static Resume</span>
+                                <span className="coming-soon-pill">Coming Soon</span>
+                            </button>
+                        </div>
+                    </div>
+                </article>
+            </section>
+
             <section className="resume-grid">
                 <article className="resume-panel resume-panel-emphasis">
                     <div className="resume-panel-heading">
@@ -205,28 +273,6 @@ export function ResumePage() {
                         <p>
                             Skill and technology emphasis will plug into this panel after the richer structured resume rendering work is complete.
                         </p>
-                    </div>
-                </article>
-            </section>
-
-            <section className="resume-action-area">
-                <article className="resume-panel resume-action-panel">
-                    <div className="resume-panel-heading">
-                        <p className="eyebrow">Action Area</p>
-                        <h2>Future actions already have a home.</h2>
-                    </div>
-
-                    <div className="resume-action-grid">
-                        <div className="resume-action-card">
-                            <span className="meta-label">PDF Export</span>
-                            <strong>Planned under issue #88</strong>
-                            <p>An ATS-friendly export action will attach to this shell without changing the page structure.</p>
-                        </div>
-                        <div className="resume-action-card">
-                            <span className="meta-label">Static Resume Link</span>
-                            <strong>{isProfileMissing ? 'Not configured' : 'Awaiting configuration support'}</strong>
-                            <p>Optional external resume delivery will surface here once the admin configuration work is available.</p>
-                        </div>
                     </div>
                 </article>
             </section>


### PR DESCRIPTION
Closes #85

## Summary
- add the public `/resume` route and enable the Resume navigation entry
- introduce a recruiter-focused resume shell with a compact sticky action rail for planned recruiter controls
- tighten project board automation so only included issues and true closing references move issues on the board
- ignore cross-repo issue references when parsing PR closing keywords so only this repository's issues are updated

## Why
Issue #85 is responsible for the public route, navigation wiring, and recruiter-oriented page shell. During review, we also found that the project board workflow was moving related issues into review when they were merely referenced in the PR body, and that cross-repo closing references could accidentally target a same-numbered issue in this repository. This branch keeps Included Issues support for promotion PRs, honors real closing references, and ignores unrelated or cross-repo references.

## Validation
- `npm test`
- `node --test .github/scripts/project-board-status.test.mjs`
