### PR TITLE
Issue #86: render structured public resume sections

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -425,6 +425,7 @@
 .resume-shell-note p,
 .resume-action-card p,
 .resume-date-range,
+.resume-role-date,
 .resume-timeline-heading p,
 .resume-experience-header p,
 .resume-role-meta p,
@@ -595,6 +596,18 @@
 .resume-date-range {
     justify-self: end;
     white-space: nowrap;
+    font-size: 0.92rem;
+}
+
+.resume-date-range,
+.resume-role-date {
+    text-decoration: underline dotted rgba(245, 183, 48, 0.45);
+    text-underline-offset: 0.22rem;
+    cursor: help;
+}
+
+.resume-role-date {
+    display: inline-block;
     font-size: 0.92rem;
 }
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -335,7 +335,17 @@
 .resume-shell-note,
 .resume-hero,
 .resume-hero-copy,
-.resume-hero-meta {
+.resume-hero-meta,
+.resume-summary-stack,
+.resume-summary-card,
+.resume-experience-list,
+.resume-experience-group,
+.resume-experience-header,
+.resume-experience-role-list,
+.resume-experience-role,
+.resume-role-meta,
+.resume-highlight-list,
+.resume-highlight-group {
     display: grid;
 }
 
@@ -355,7 +365,15 @@
 .resume-panel,
 .resume-shell-note,
 .resume-link-card,
-.resume-action-card {
+.resume-action-card,
+.resume-summary-stack,
+.resume-summary-card,
+.resume-experience-list,
+.resume-experience-group,
+.resume-experience-role-list,
+.resume-experience-role,
+.resume-highlight-list,
+.resume-highlight-group {
     gap: 0.9rem;
 }
 
@@ -389,7 +407,10 @@
 .resume-callout-card strong,
 .resume-panel h2,
 .resume-timeline-heading h3,
-.resume-action-card strong {
+.resume-action-card strong,
+.resume-summary-card strong,
+.resume-experience-header h3,
+.resume-role-meta strong {
     margin: 0;
     color: #fff7e8;
 }
@@ -404,7 +425,10 @@
 .resume-shell-note p,
 .resume-action-card p,
 .resume-date-range,
-.resume-timeline-heading p {
+.resume-timeline-heading p,
+.resume-experience-header p,
+.resume-role-meta p,
+.resume-role-copy {
     margin: 0;
     color: rgba(219, 230, 243, 0.82);
     line-height: 1.65;
@@ -499,6 +523,50 @@
 .resume-link-card:hover {
     transform: translateY(-1px);
     border-color: rgba(126, 233, 255, 0.22);
+}
+
+.resume-summary-card,
+.resume-experience-role {
+    padding: 1rem 1.05rem;
+    border-radius: 1.05rem;
+    border: 1px solid rgba(111, 137, 171, 0.18);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.resume-summary-card {
+    gap: 0.35rem;
+}
+
+.resume-experience-list {
+    gap: 1rem;
+}
+
+.resume-experience-group {
+    gap: 0.95rem;
+    padding: 1rem 1.05rem;
+    border-radius: 1.15rem;
+    border: 1px solid rgba(111, 137, 171, 0.16);
+    background:
+        linear-gradient(180deg, rgba(10, 24, 40, 0.7), rgba(8, 19, 33, 0.72)),
+        radial-gradient(circle at top right, rgba(99, 222, 255, 0.06), transparent 38%);
+}
+
+.resume-experience-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.85rem;
+    align-items: start;
+}
+
+.resume-experience-role {
+    gap: 0.75rem;
+}
+
+.resume-role-meta {
+    gap: 0.2rem;
+}
+
+.resume-highlight-group {
+    gap: 0.55rem;
 }
 
 .resume-shell-note {
@@ -2260,7 +2328,8 @@
         position: static;
     }
 
-    .resume-timeline-heading {
+    .resume-timeline-heading,
+    .resume-experience-header {
         grid-template-columns: 1fr;
     }
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -378,7 +378,7 @@ describe('App', () => {
 
         expect(await screen.findByRole('heading', { name: 'Bronze Loft' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Resume' })).toHaveAttribute('aria-current', 'page');
-        expect(screen.getByText('Open to senior full-stack roles')).toBeInTheDocument();
+        expect(screen.getAllByText('Open to senior full-stack roles')).toHaveLength(2);
         expect(screen.getByText('Senior Software Engineer')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /bronze@example\.dev/i })).toHaveAttribute('href', 'mailto:bronze@example.dev');
         expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -21,10 +21,10 @@ function createProfile(overrides: Partial<PortfolioProfile> = {}): PortfolioProf
     return {
         id: 1,
         displayName: 'Bronze Loft',
-        contactHeadline: 'Reach out.',
-        contactIntro: 'Profile summary.',
-        availabilityHeadline: 'Available now',
-        availabilitySummary: 'Ready for the next role.',
+        contactHeadline: 'Full-stack engineer focused on dependable delivery.',
+        contactIntro: 'I build portfolio, product, and platform experiences that stay usable under real operating pressure.',
+        availabilityHeadline: 'Open to senior product engineering roles',
+        availabilitySummary: 'Remote-friendly, collaborative, and comfortable owning delivery from API to UI polish.',
         contactMethods: [],
         socialLinks: [],
         ...overrides
@@ -42,9 +42,9 @@ function createEmployer(id: number, overrides: Partial<Employer> = {}): Employer
                 role: `Role ${id}`,
                 startDate: '2024-01-08',
                 endDate: null,
-                descriptionMarkdown: 'Built and shipped product work.',
-                skills: [],
-                technologies: []
+                descriptionMarkdown: 'Built and shipped product work.\n\nPartnered with stakeholders to keep the roadmap moving.',
+                skills: [`Skill ${id}`],
+                technologies: [`Technology ${id}`]
             }
         ],
         ...overrides
@@ -114,7 +114,7 @@ describe('ResumePage', () => {
         expect(within(signalCard as HTMLElement).queryByRole('link')).not.toBeInTheDocument();
     });
 
-    it('shows empty-state copy and missing-config action state when public data is unavailable', () => {
+    it('shows empty-state copy and hides optional sections when public data is unavailable', () => {
         mockUsePortfolioProfile.mockReturnValue({
             profile: null,
             isLoading: false,
@@ -135,23 +135,64 @@ describe('ResumePage', () => {
         expect(screen.getByText('Needs config')).toBeInTheDocument();
         expect(screen.getByText('Public contact and social links will appear here once the portfolio profile is configured.')).toBeInTheDocument();
         expect(screen.getByText('Published work history will appear here once employer and job-role records are available.')).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Positioning for recruiters and hiring teams.' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Core skills and technologies.' })).not.toBeInTheDocument();
     });
 
-    it('limits the experience shell to the first three employers', () => {
+    it('renders structured summary, skill highlights, and full experience history', () => {
         mockUseWorkHistory.mockReturnValue({
-            employers: [createEmployer(1), createEmployer(2), createEmployer(3), createEmployer(4)],
+            employers: [
+                createEmployer(1),
+                createEmployer(2, {
+                    city: 'Austin',
+                    region: 'TX',
+                    jobRoles: [
+                        {
+                            role: 'Principal Engineer',
+                            startDate: '2021-05-03',
+                            endDate: '2023-12-15',
+                            descriptionMarkdown: 'Directed architecture strategy and delivery planning.',
+                            skills: ['Architecture', 'Leadership'],
+                            technologies: ['React', '.NET 10']
+                        },
+                        {
+                            role: 'Senior Engineer',
+                            startDate: '2019-02-11',
+                            endDate: '2021-05-01',
+                            descriptionMarkdown: 'Led service migrations and performance work.',
+                            skills: ['Performance'],
+                            technologies: ['SQL Server']
+                        }
+                    ]
+                }),
+                createEmployer(3),
+                createEmployer(4)
+            ],
             isLoading: false,
             error: null
         });
 
         render(<ResumePage />);
 
-        const experiencePanel = screen.getByText('Experience Shell').closest('article');
-        expect(experiencePanel).not.toBeNull();
+        const summaryPanel = screen.getByRole('heading', { name: 'Positioning for recruiters and hiring teams.' }).closest('article');
+        expect(summaryPanel).not.toBeNull();
+        expect(within(summaryPanel as HTMLElement).getByText('Full-stack engineer focused on dependable delivery.')).toBeInTheDocument();
+        expect(within(summaryPanel as HTMLElement).getByText('Remote-friendly, collaborative, and comfortable owning delivery from API to UI polish.')).toBeInTheDocument();
 
+        expect(screen.getByRole('heading', { name: 'Core skills and technologies.' })).toBeInTheDocument();
+        expect(screen.getByLabelText('Resume skills')).toHaveTextContent('Skill 1');
+        expect(screen.getByLabelText('Resume skills')).toHaveTextContent('Architecture');
+        expect(screen.getByLabelText('Resume technologies')).toHaveTextContent('.NET 10');
+        expect(screen.getByLabelText('Resume technologies')).toHaveTextContent('React');
+
+        const experiencePanel = screen.getByRole('heading', { name: 'Condensed work history.' }).closest('article');
+        expect(experiencePanel).not.toBeNull();
         expect(within(experiencePanel as HTMLElement).getByRole('heading', { name: 'Employer 1' })).toBeInTheDocument();
         expect(within(experiencePanel as HTMLElement).getByRole('heading', { name: 'Employer 2' })).toBeInTheDocument();
         expect(within(experiencePanel as HTMLElement).getByRole('heading', { name: 'Employer 3' })).toBeInTheDocument();
-        expect(within(experiencePanel as HTMLElement).queryByRole('heading', { name: 'Employer 4' })).not.toBeInTheDocument();
+        expect(within(experiencePanel as HTMLElement).getByRole('heading', { name: 'Employer 4' })).toBeInTheDocument();
+        expect(within(experiencePanel as HTMLElement).getByText('Directed architecture strategy and delivery planning.')).toBeInTheDocument();
+        expect(within(experiencePanel as HTMLElement).getByLabelText('Principal Engineer skills')).toHaveTextContent('Architecture');
+        expect(within(experiencePanel as HTMLElement).getByLabelText('Principal Engineer technologies')).toHaveTextContent('.NET 10');
     });
 });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -54,9 +54,12 @@ function createEmployer(id: number, overrides: Partial<Employer> = {}): Employer
 describe('ResumePage', () => {
     afterEach(() => {
         cleanup();
+        vi.useRealTimers();
     });
 
     beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-24T12:00:00Z'));
         mockUsePortfolioProfile.mockReturnValue({
             profile: createProfile(),
             isLoading: false,
@@ -194,5 +197,44 @@ describe('ResumePage', () => {
         expect(within(experiencePanel as HTMLElement).getByText('Directed architecture strategy and delivery planning.')).toBeInTheDocument();
         expect(within(experiencePanel as HTMLElement).getByLabelText('Principal Engineer skills')).toHaveTextContent('Architecture');
         expect(within(experiencePanel as HTMLElement).getByLabelText('Principal Engineer technologies')).toHaveTextContent('.NET 10');
+        expect(within(experiencePanel as HTMLElement).getByText('Feb 2019 to Dec 2023')).toHaveAttribute('title', 'Time at Employer 2: 4 years, 11 months');
+        expect(within(experiencePanel as HTMLElement).getByText('May 2021 to Dec 2023')).toHaveAttribute('title', 'Time in role: 2 years, 8 months');
+        expect(within(experiencePanel as HTMLElement).getByText('Feb 2019 to May 2021')).toHaveAttribute('title', 'Time in role: 2 years, 4 months');
+    });
+
+    it('avoids duplicate key warnings when role titles and start dates repeat', () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        mockUseWorkHistory.mockReturnValue({
+            employers: [
+                createEmployer(1, {
+                    jobRoles: [
+                        {
+                            role: 'Software Engineer',
+                            startDate: '2022-01-10',
+                            endDate: '2022-12-20',
+                            descriptionMarkdown: 'Supported release work.',
+                            skills: ['Testing'],
+                            technologies: ['React']
+                        },
+                        {
+                            role: 'Software Engineer',
+                            startDate: '2022-01-10',
+                            endDate: '2023-06-15',
+                            descriptionMarkdown: 'Expanded platform ownership.',
+                            skills: ['Architecture'],
+                            technologies: ['.NET 10']
+                        }
+                    ]
+                })
+            ],
+            isLoading: false,
+            error: null
+        });
+
+        render(<ResumePage />);
+
+        expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Encountered two children with the same key'));
+        consoleErrorSpy.mockRestore();
     });
 });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -1,3 +1,4 @@
+import type { JobRole } from '../../app/types';
 import { formatProjectDates } from '../../appSupport';
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
 import { useWorkHistory } from '../../hooks/useWorkHistory';
@@ -18,6 +19,42 @@ function getResumeContactHref(value: string) {
     return '';
 }
 
+function getOrderedUniqueValues(values: string[]) {
+    const seen = new Set<string>();
+
+    return values.filter(value => {
+        const trimmedValue = value.trim();
+        if (!trimmedValue || seen.has(trimmedValue)) {
+            return false;
+        }
+
+        seen.add(trimmedValue);
+        return true;
+    });
+}
+
+function getLocationLabel(city?: string | null, region?: string | null) {
+    const parts = [city?.trim(), region?.trim()].filter(part => part && part.length > 0);
+    return parts.length > 0 ? parts.join(', ') : null;
+}
+
+function getEmployerDateRange(jobRoles: JobRole[]) {
+    if (jobRoles.length === 0) {
+        return null;
+    }
+
+    const newestRole = jobRoles[0];
+    const oldestRole = jobRoles[jobRoles.length - 1];
+    return formatProjectDates(oldestRole.startDate, newestRole.endDate);
+}
+
+function getDescriptionSummary(markdown: string) {
+    return markdown
+        .split(/\r?\n\r?\n/)
+        .map(paragraph => paragraph.trim().replace(/^#+\s*/, ''))
+        .find(paragraph => paragraph.length > 0) ?? '';
+}
+
 export function ResumePage() {
     const {
         profile,
@@ -31,14 +68,25 @@ export function ResumePage() {
         error: workHistoryError
     } = useWorkHistory();
 
-    const roleCount = employers.reduce((total, employer) => total + employer.jobRoles.length, 0);
+    const roleRecords = employers.flatMap(employer => employer.jobRoles.map(jobRole => ({
+        employer,
+        jobRole
+    })));
+    const roleCount = roleRecords.length;
+    const primaryRole = roleRecords.find(record => record.jobRole.role.trim().length > 0)?.jobRole;
     const location = employers
-        .map(employer => [employer.city, employer.region].filter(Boolean).join(', '))
-        .find(value => value.length > 0);
-    const primaryRole = employers.flatMap(employer => employer.jobRoles).find(role => role.role.trim().length > 0);
+        .map(employer => getLocationLabel(employer.city, employer.region))
+        .find(Boolean);
     const contactMethods = (profile?.contactMethods ?? []).slice(0, 3);
     const socialLinks = (profile?.socialLinks ?? []).slice(0, 2);
-    const sampleEmployers = employers.slice(0, 3);
+    const contactChannelCount = contactMethods.length + socialLinks.length;
+    const summaryParagraphs = [profile?.contactIntro?.trim(), profile?.availabilitySummary?.trim()].filter(
+        (value): value is string => Boolean(value && value.length > 0)
+    );
+    const skillHighlights = getOrderedUniqueValues(roleRecords.flatMap(record => record.jobRole.skills)).slice(0, 8);
+    const technologyHighlights = getOrderedUniqueValues(roleRecords.flatMap(record => record.jobRole.technologies)).slice(0, 8);
+    const hasSummarySection = Boolean(profile?.contactHeadline?.trim() || profile?.availabilityHeadline?.trim() || summaryParagraphs.length > 0);
+    const hasSkillsSection = skillHighlights.length > 0 || technologyHighlights.length > 0;
     const isLoading = isProfileLoading || isWorkHistoryLoading;
     const errors = [profileError, workHistoryError].filter(Boolean);
 
@@ -48,7 +96,7 @@ export function ResumePage() {
                 <p key={error} className="status-banner error">{error}</p>
             ))}
             {!errors.length && isLoading ? (
-                <p className="status-banner">Loading resume shell...</p>
+                <p className="status-banner">Loading resume...</p>
             ) : null}
 
             <section className="hero-panel resume-hero">
@@ -56,9 +104,11 @@ export function ResumePage() {
                     <p className="eyebrow">Public Resume</p>
                     <h1>{profile?.displayName ?? 'Resume shell ready for public portfolio data.'}</h1>
                     <p className="hero-description">
-                        {primaryRole?.role
-                            ? `${primaryRole.role}${location ? ` based in ${location}` : ''}. This recruiter-focused view is built to stay concise, skimmable, and ready for richer structured sections.`
-                            : 'This page establishes the recruiter-focused resume shell so structured sections, filtering, and export actions can plug in without reworking the layout.'}
+                        {profile?.contactHeadline?.trim()
+                            ? profile.contactHeadline
+                            : primaryRole?.role
+                                ? `${primaryRole.role}${location ? ` based in ${location}` : ''}. This recruiter-focused view stays concise while turning published portfolio data into a skimmable resume.`
+                                : 'This page turns published profile and work-history data into a recruiter-facing resume layout once those records are available.'}
                     </p>
                 </div>
 
@@ -67,7 +117,7 @@ export function ResumePage() {
                         <span className="stat-label">Resume Snapshot</span>
                         <strong>{roleCount > 0 ? getRoleCount(employers.length, roleCount) : 'Waiting for published resume data'}</strong>
                         <p>
-                            {profile?.availabilityHeadline
+                            {profile?.availabilityHeadline?.trim()
                                 ? profile.availabilityHeadline
                                 : 'Publish public profile and work history records to turn this shell into a complete recruiter-facing resume.'}
                         </p>
@@ -84,7 +134,7 @@ export function ResumePage() {
                         </div>
                         <div className="stat-card">
                             <span className="stat-label">Contact Channels</span>
-                            <strong>{contactMethods.length + socialLinks.length}</strong>
+                            <strong>{contactChannelCount}</strong>
                         </div>
                     </div>
                 </div>
@@ -162,7 +212,7 @@ export function ResumePage() {
                 <article className="resume-panel resume-panel-emphasis">
                     <div className="resume-panel-heading">
                         <p className="eyebrow">Header</p>
-                        <h2>Recruiter essentials up front.</h2>
+                        <h2>Contact and portfolio links.</h2>
                     </div>
 
                     {contactMethods.length > 0 || socialLinks.length > 0 ? (
@@ -209,49 +259,97 @@ export function ResumePage() {
                     )}
                 </article>
 
-                <article className="resume-panel">
-                    <div className="resume-panel-heading">
-                        <p className="eyebrow">Profile Section</p>
-                        <h2>Summary area reserved for concise positioning.</h2>
-                    </div>
+                {hasSummarySection ? (
+                    <article className="resume-panel">
+                        <div className="resume-panel-heading">
+                            <p className="eyebrow">Career Summary</p>
+                            <h2>Positioning for recruiters and hiring teams.</h2>
+                        </div>
 
-                    <div className="resume-shell-note">
-                        <p>
-                            {profile?.contactIntro
-                                ? profile.contactIntro
-                                : 'A short recruiter-facing profile summary will land here once the public portfolio profile is ready for resume presentation.'}
-                        </p>
-                    </div>
-                </article>
+                        <div className="resume-summary-stack">
+                            {profile?.contactHeadline?.trim() ? (
+                                <div className="resume-summary-card">
+                                    <span className="meta-label">Headline</span>
+                                    <strong>{profile.contactHeadline}</strong>
+                                </div>
+                            ) : null}
+                            {profile?.availabilityHeadline?.trim() ? (
+                                <div className="resume-summary-card">
+                                    <span className="meta-label">Availability</span>
+                                    <strong>{profile.availabilityHeadline}</strong>
+                                </div>
+                            ) : null}
+                            {summaryParagraphs.map(paragraph => (
+                                <p key={paragraph} className="secondary-copy">{paragraph}</p>
+                            ))}
+                        </div>
+                    </article>
+                ) : null}
             </section>
 
             <section className="resume-grid resume-grid-secondary">
                 <article className="resume-panel">
                     <div className="resume-panel-heading">
-                        <p className="eyebrow">Experience Shell</p>
-                        <h2>Space reserved for condensed role history.</h2>
+                        <p className="eyebrow">Experience</p>
+                        <h2>Condensed work history.</h2>
                     </div>
 
-                    {sampleEmployers.length > 0 ? (
-                        <div className="resume-timeline">
-                            {sampleEmployers.map(employer => {
-                                const latestRole = employer.jobRoles[0];
+                    {employers.length > 0 ? (
+                        <div className="resume-experience-list">
+                            {employers.map(employer => {
+                                const employerLocation = getLocationLabel(employer.city, employer.region);
+                                const employerRange = getEmployerDateRange(employer.jobRoles);
+
                                 return (
-                                    <section key={employer.id} className="resume-timeline-item">
-                                        <div className="resume-timeline-heading">
+                                    <section key={employer.id} className="resume-experience-group">
+                                        <div className="resume-experience-header">
                                             <div>
                                                 <h3>{employer.name}</h3>
-                                                <p>{latestRole?.role ?? 'Published role details will appear here.'}</p>
+                                                {employerLocation ? <p>{employerLocation}</p> : null}
                                             </div>
-                                            {latestRole ? (
-                                                <span className="resume-date-range">
-                                                    {formatProjectDates(latestRole.startDate, latestRole.endDate)}
-                                                </span>
+                                            {employerRange ? (
+                                                <span className="resume-date-range">{employerRange}</span>
                                             ) : null}
                                         </div>
-                                        <p className="helper-copy">
-                                            Full recruiter-focused role bullets, skill highlights, and optional sections are intentionally deferred to the next resume issue.
-                                        </p>
+
+                                        <div className="resume-experience-role-list">
+                                            {employer.jobRoles.map(jobRole => {
+                                                const summary = getDescriptionSummary(jobRole.descriptionMarkdown);
+
+                                                return (
+                                                    <article
+                                                        key={`${employer.id}-${jobRole.role}-${jobRole.startDate}`}
+                                                        className="resume-experience-role">
+                                                        <div className="resume-role-meta">
+                                                            <div>
+                                                                <strong>{jobRole.role}</strong>
+                                                                <p>{formatProjectDates(jobRole.startDate, jobRole.endDate)}</p>
+                                                            </div>
+                                                        </div>
+
+                                                        {summary ? (
+                                                            <p className="resume-role-copy">{summary}</p>
+                                                        ) : null}
+
+                                                        {jobRole.skills.length > 0 ? (
+                                                            <div className="tag-group" aria-label={`${jobRole.role} skills`}>
+                                                                {jobRole.skills.map(skill => (
+                                                                    <span key={skill} className="tag skill">{skill}</span>
+                                                                ))}
+                                                            </div>
+                                                        ) : null}
+
+                                                        {jobRole.technologies.length > 0 ? (
+                                                            <div className="tag-group secondary" aria-label={`${jobRole.role} technologies`}>
+                                                                {jobRole.technologies.map(technology => (
+                                                                    <span key={technology} className="tag technology">{technology}</span>
+                                                                ))}
+                                                            </div>
+                                                        ) : null}
+                                                    </article>
+                                                );
+                                            })}
+                                        </div>
                                     </section>
                                 );
                             })}
@@ -263,18 +361,38 @@ export function ResumePage() {
                     )}
                 </article>
 
-                <article className="resume-panel">
-                    <div className="resume-panel-heading">
-                        <p className="eyebrow">Skills Shell</p>
-                        <h2>Reserved for scan-friendly capability highlights.</h2>
-                    </div>
+                {hasSkillsSection ? (
+                    <article className="resume-panel">
+                        <div className="resume-panel-heading">
+                            <p className="eyebrow">Skills</p>
+                            <h2>Core skills and technologies.</h2>
+                        </div>
 
-                    <div className="resume-shell-note">
-                        <p>
-                            Skill and technology emphasis will plug into this panel after the richer structured resume rendering work is complete.
-                        </p>
-                    </div>
-                </article>
+                        <div className="resume-highlight-list">
+                            {skillHighlights.length > 0 ? (
+                                <section className="resume-highlight-group">
+                                    <span className="meta-label">Skills</span>
+                                    <div className="tag-group" aria-label="Resume skills">
+                                        {skillHighlights.map(skill => (
+                                            <span key={skill} className="tag skill">{skill}</span>
+                                        ))}
+                                    </div>
+                                </section>
+                            ) : null}
+
+                            {technologyHighlights.length > 0 ? (
+                                <section className="resume-highlight-group">
+                                    <span className="meta-label">Technologies</span>
+                                    <div className="tag-group secondary" aria-label="Resume technologies">
+                                        {technologyHighlights.map(technology => (
+                                            <span key={technology} className="tag technology">{technology}</span>
+                                        ))}
+                                    </div>
+                                </section>
+                            ) : null}
+                        </div>
+                    </article>
+                ) : null}
             </section>
         </main>
     );

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -3,6 +3,17 @@ import { formatProjectDates } from '../../appSupport';
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
 import { useWorkHistory } from '../../hooks/useWorkHistory';
 
+interface ResumeDateValue {
+    label: string;
+    title: string;
+}
+
+interface ResumeRoleEntry {
+    jobRole: JobRole;
+    key: string;
+    dateValue: ResumeDateValue;
+}
+
 function getRoleCount(employerCount: number, roleCount: number) {
     return `${roleCount} role${roleCount === 1 ? '' : 's'} across ${employerCount} employer${employerCount === 1 ? '' : 's'}`;
 }
@@ -38,14 +49,68 @@ function getLocationLabel(city?: string | null, region?: string | null) {
     return parts.length > 0 ? parts.join(', ') : null;
 }
 
-function getEmployerDateRange(jobRoles: JobRole[]) {
+function getDateMonthValue(value: string) {
+    const [year, month] = value.split('-').map(Number);
+    return {
+        year,
+        month
+    };
+}
+
+function getMonthDistance(startDate: string, endDate?: string | null) {
+    const start = getDateMonthValue(startDate);
+    const end = endDate ? getDateMonthValue(endDate) : {
+        year: new Date().getFullYear(),
+        month: new Date().getMonth() + 1
+    };
+
+    return Math.max(0, ((end.year - start.year) * 12) + (end.month - start.month) + 1);
+}
+
+function formatDurationLabel(totalMonths: number) {
+    const years = Math.floor(totalMonths / 12);
+    const months = totalMonths % 12;
+    const parts: string[] = [];
+
+    if (years > 0) {
+        parts.push(`${years} year${years === 1 ? '' : 's'}`);
+    }
+
+    if (months > 0 || parts.length === 0) {
+        parts.push(`${months} month${months === 1 ? '' : 's'}`);
+    }
+
+    return parts.join(', ');
+}
+
+function createDateValue(startDate: string, endDate: string | null | undefined, titlePrefix: string): ResumeDateValue {
+    return {
+        label: formatProjectDates(startDate, endDate),
+        title: `${titlePrefix}: ${formatDurationLabel(getMonthDistance(startDate, endDate))}`
+    };
+}
+
+function getEmployerDateValue(employerName: string, jobRoles: JobRole[]) {
     if (jobRoles.length === 0) {
         return null;
     }
 
-    const newestRole = jobRoles[0];
-    const oldestRole = jobRoles[jobRoles.length - 1];
-    return formatProjectDates(oldestRole.startDate, newestRole.endDate);
+    const earliestRole = jobRoles.reduce((currentEarliest, role) => role.startDate < currentEarliest.startDate ? role : currentEarliest);
+    const activeRole = jobRoles.find(role => !role.endDate);
+    const latestCompletedRole = jobRoles.reduce((currentLatest, role) => {
+        if (!role.endDate) {
+            return currentLatest;
+        }
+
+        if (!currentLatest || role.endDate > (currentLatest.endDate ?? '')) {
+            return role;
+        }
+
+        return currentLatest;
+    }, null as JobRole | null);
+    const latestEndDate = activeRole ? null : latestCompletedRole?.endDate;
+
+    return createDateValue(earliestRole.startDate, latestEndDate, `Time at ${employerName}`);
 }
 
 function getDescriptionSummary(markdown: string) {
@@ -53,6 +118,34 @@ function getDescriptionSummary(markdown: string) {
         .split(/\r?\n\r?\n/)
         .map(paragraph => paragraph.trim().replace(/^#+\s*/, ''))
         .find(paragraph => paragraph.length > 0) ?? '';
+}
+
+function getJobRoleKeySignature(jobRole: JobRole) {
+    return [
+        jobRole.role,
+        jobRole.startDate,
+        jobRole.endDate ?? 'present',
+        jobRole.supervisorName ?? '',
+        jobRole.descriptionMarkdown,
+        jobRole.skills.join(','),
+        jobRole.technologies.join(',')
+    ].join('|');
+}
+
+function buildResumeRoleEntries(jobRoles: JobRole[]) {
+    const seenSignatures = new Map<string, number>();
+
+    return jobRoles.map(jobRole => {
+        const signature = getJobRoleKeySignature(jobRole);
+        const occurrence = (seenSignatures.get(signature) ?? 0) + 1;
+        seenSignatures.set(signature, occurrence);
+
+        return {
+            jobRole,
+            key: `${signature}|${occurrence}`,
+            dateValue: createDateValue(jobRole.startDate, jobRole.endDate, 'Time in role')
+        };
+    });
 }
 
 export function ResumePage() {
@@ -298,7 +391,8 @@ export function ResumePage() {
                         <div className="resume-experience-list">
                             {employers.map(employer => {
                                 const employerLocation = getLocationLabel(employer.city, employer.region);
-                                const employerRange = getEmployerDateRange(employer.jobRoles);
+                                const employerDateValue = getEmployerDateValue(employer.name, employer.jobRoles);
+                                const roleEntries = buildResumeRoleEntries(employer.jobRoles);
 
                                 return (
                                     <section key={employer.id} className="resume-experience-group">
@@ -307,23 +401,27 @@ export function ResumePage() {
                                                 <h3>{employer.name}</h3>
                                                 {employerLocation ? <p>{employerLocation}</p> : null}
                                             </div>
-                                            {employerRange ? (
-                                                <span className="resume-date-range">{employerRange}</span>
+                                            {employerDateValue ? (
+                                                <abbr className="resume-date-range" title={employerDateValue.title}>
+                                                    {employerDateValue.label}
+                                                </abbr>
                                             ) : null}
                                         </div>
 
                                         <div className="resume-experience-role-list">
-                                            {employer.jobRoles.map(jobRole => {
+                                            {roleEntries.map(({ jobRole, key, dateValue }: ResumeRoleEntry) => {
                                                 const summary = getDescriptionSummary(jobRole.descriptionMarkdown);
 
                                                 return (
                                                     <article
-                                                        key={`${employer.id}-${jobRole.role}-${jobRole.startDate}`}
+                                                        key={`${employer.id}-${key}`}
                                                         className="resume-experience-role">
                                                         <div className="resume-role-meta">
                                                             <div>
                                                                 <strong>{jobRole.role}</strong>
-                                                                <p>{formatProjectDates(jobRole.startDate, jobRole.endDate)}</p>
+                                                                <abbr className="resume-role-date" title={dateValue.title}>
+                                                                    {dateValue.label}
+                                                                </abbr>
                                                             </div>
                                                         </div>
 

--- a/TODO.MD
+++ b/TODO.MD
@@ -12,3 +12,4 @@
 - Consider showing the logged-in user's display name in the admin navigation or header once the MVP admin shell is stable.
 - Add account lockout and related login hardening rules in a follow-up issue after the MVP authentication flow is in place.
 - Add an admin tag editor in a separate issue so shared skill and technology tags can be curated without coupling that UI to the current work history delivery scope.
+- Consider showing explicit per-role duration on the public resume page, not just start/end dates, for employers with multiple roles (for example, `Senior Software Engineer` vs `Software Engineer` at the same employer).


### PR DESCRIPTION
## Summary
- replace the resume shell placeholders with recruiter-focused summary, skills, and condensed experience sections
- derive resume highlights directly from published portfolio profile and work-history data while hiding optional sections when data is missing
- refresh resume page tests and app route coverage for the richer structured rendering

## Testing
- npm test
- npm run lint
- npm run build

Closes #86