### PR TITLE
[codex] Issue #87: add recruiter-focused resume filters

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioSeedDataTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/PortfolioSeedDataTests.cs
@@ -36,16 +36,18 @@ public sealed class PortfolioSeedDataTests
 
         Assert.That(profiles, Has.Count.EqualTo(1));
         Assert.That(profiles[0].IsPublic, Is.True);
+        Assert.That(profiles[0].DisplayName, Is.EqualTo("Bronze Harold Brown"));
         Assert.That(profiles[0].ContactMethods, Has.Count.EqualTo(3));
-        Assert.That(profiles[0].SocialLinks, Has.Count.EqualTo(3));
+        Assert.That(profiles[0].SocialLinks, Has.Count.EqualTo(2));
         Assert.That(projects, Has.Count.EqualTo(100));
-        Assert.That(employers, Has.Count.EqualTo(2));
+        Assert.That(employers, Has.Count.EqualTo(15));
         Assert.That(projects.All(project => project.Screenshots.Count >= 2), Is.True);
         Assert.That(projects.Single(project => project.Title == "Project Portfolio 2026").Screenshots, Has.Count.EqualTo(6));
         Assert.That(projects.All(project => project.DeveloperRoles.Count > 0), Is.True);
         Assert.That(projects.All(project => project.ProjectTags.Any(projectTag => projectTag.Tag!.Category == ProjectPortfolio2026.Server.Domain.Tags.TagCategory.Technology)), Is.True);
         Assert.That(projects.All(project => project.ProjectTags.Any(projectTag => projectTag.Tag!.Category == ProjectPortfolio2026.Server.Domain.Tags.TagCategory.Skill)), Is.True);
         Assert.That(employers.All(employer => employer.JobRoles.Count > 0), Is.True);
+        Assert.That(employers.Any(employer => employer.Name == "Axl Protocol Music"), Is.True);
         Assert.That(employers.SelectMany(employer => employer.JobRoles).All(jobRole => jobRole.JobRoleTags.Count > 0), Is.True);
         Assert.That(projects.All(project => project.Milestones.Count > 0), Is.True);
         Assert.That(projects.Count(project => project.EndDate is null), Is.EqualTo(3));

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/SeedData/PortfolioSeedData.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/SeedData/PortfolioSeedData.cs
@@ -48,11 +48,11 @@ public static class PortfolioSeedData
     {
         return new PortfolioProfile
         {
-            DisplayName = "Bronze Loft",
-            ContactHeadline = "Choose the contact path that fits the conversation you want to have.",
-            ContactIntro = "This portfolio frames outreach as a calm next step. Recruiters, collaborators, and hiring teams should be able to find the right channel quickly without sorting through hardcoded one-off content.",
-            AvailabilityHeadline = "Open to new opportunities",
-            AvailabilitySummary = "Focused on full-stack product engineering roles where API design, thoughtful UI, and maintainable delivery all matter.",
+            DisplayName = "Bronze Harold Brown",
+            ContactHeadline = "Senior .NET Cloud & AI-Integrated Engineer",
+            ContactIntro = "Senior .NET engineer with 12+ years of experience designing, building, testing, deploying, and supporting software solutions across healthcare, insurance, finance, and music technology. Strongest depth is in backend C#/.NET development, API design, data integration, debugging, production troubleshooting, and SQL-backed business systems, with growing hands-on React experience through current project work.",
+            AvailabilityHeadline = "Open to senior .NET, full-stack, cloud, and AI-integrated engineering roles.",
+            AvailabilitySummary = "Best fit is backend-heavy C#/.NET work with room to contribute across the stack, deepen frontend experience, support architecture and mentorship, and use AI tools responsibly as part of practical software delivery.",
             IsPublic = true,
             ContactMethods =
             [
@@ -60,8 +60,8 @@ public static class PortfolioSeedData
                 {
                     Type = "email",
                     Label = "Email",
-                    Value = "bronze@example.dev",
-                    Note = "Best for interview requests, consulting inquiries, and longer-form conversations.",
+                    Value = "Bronze.H.Brown@gmail.com",
+                    Note = "Best for interview requests, consulting inquiries, and recruiter conversations.",
                     SortOrder = 1,
                     IsVisible = true
                 },
@@ -69,8 +69,8 @@ public static class PortfolioSeedData
                 {
                     Type = "phone",
                     Label = "Phone",
-                    Value = "(312) 555-0147",
-                    Note = "Available for scheduled calls on weekdays between 9 AM and 5 PM Central.",
+                    Value = "(240) 758-6723",
+                    Note = "Available for scheduled calls and follow-up conversations.",
                     SortOrder = 2,
                     IsVisible = true
                 },
@@ -78,8 +78,8 @@ public static class PortfolioSeedData
                 {
                     Type = "location",
                     Label = "Location",
-                    Value = "Chicago, Illinois",
-                    Note = "Open to remote roles, hybrid collaboration, and select on-site visits.",
+                    Value = "Madison Lake, Minnesota",
+                    Note = "Open to remote roles and broader engineering collaboration.",
                     SortOrder = 3,
                     IsVisible = true
                 }
@@ -92,7 +92,7 @@ public static class PortfolioSeedData
                     Label = "GitHub",
                     Url = "https://github.com/darkdhamon",
                     Handle = "@darkdhamon",
-                    Summary = "Code samples, ongoing portfolio work, and implementation details.",
+                    Summary = "Public source code, current portfolio work, and implementation details.",
                     SortOrder = 1,
                     IsVisible = true
                 },
@@ -100,20 +100,10 @@ public static class PortfolioSeedData
                 {
                     Platform = "linkedin",
                     Label = "LinkedIn",
-                    Url = "https://www.linkedin.com/in/bronze-loft",
-                    Handle = "Bronze Loft",
-                    Summary = "Professional background, role history, and recruiter-friendly context.",
+                    Url = "https://www.linkedin.com/in/bronzeharoldbrown/",
+                    Handle = "Bronze Harold Brown",
+                    Summary = "Professional background, role history, and recruiter-facing context.",
                     SortOrder = 2,
-                    IsVisible = true
-                },
-                new PortfolioSocialLink
-                {
-                    Platform = "calendly",
-                    Label = "Calendly",
-                    Url = "https://calendly.com/bronze-loft/portfolio-intro",
-                    Handle = "Schedule an intro",
-                    Summary = "A lightweight path for a first conversation without email back-and-forth.",
-                    SortOrder = 3,
                     IsVisible = true
                 }
             ]
@@ -525,56 +515,347 @@ public static class PortfolioSeedData
         [
             new Employer
             {
-                Name = "Northwind Health",
-                City = "Chicago",
-                Region = "IL",
+                Name = "Axl Protocol Music",
+                City = "Madison Lake",
+                Region = "MN",
                 Country = "USA",
                 IsPublished = true,
                 JobRoles =
                 [
                     CreateJobRole(
-                        "Senior Software Engineer",
-                        new DateOnly(2024, 1, 8),
+                        ".NET Full-Stack Cloud Engineer",
+                        new DateOnly(2024, 10, 1),
                         null,
-                        "Dana Smith",
+                        null,
                         """
-                        Leading API delivery, platform refactoring, and public-facing portfolio architecture work.
+                        Led the architecture and delivery of a .NET 10 Blazor web application with interactive server rendering, backed by MongoDB and deployed to Azure App Service.
 
-                        Partnering with product and design stakeholders to align engineering implementation with recruiting and resume-generation goals.
+                        Owned the full software development lifecycle from concept and requirements through implementation, testing, deployment, support, CI quality gates, analytics, and OpenAI-assisted platform features under my technical direction.
                         """,
-                        skills: ["API Design", "Technical Writing"],
-                        technologies: [".NET 10", "SQL Server"]),
-                    CreateJobRole(
-                        "Software Engineer",
-                        new DateOnly(2022, 4, 4),
-                        new DateOnly(2023, 12, 29),
-                        "Dana Smith",
-                        """
-                        Delivered internal business applications and improved deployment reliability for line-of-business systems.
-                        """,
-                        skills: ["Workflow Design", "Testing"],
-                        technologies: ["ASP.NET Core", "Azure DevOps"])
+                        skills: ["Application Architecture", "AI Integration", "CI/CD", "Content Management", "Analytics"],
+                        technologies: [".NET 10", "Blazor", "ASP.NET Core", "MongoDB", "Azure App Service", "GitHub Actions", "OpenAI Responses API"])
                 ]
             },
             new Employer
             {
-                Name = "Blue Ocean Labs",
-                City = "Austin",
-                Region = "TX",
+                Name = "Tata Consultancy Services (TCS)",
+                City = null,
+                Region = null,
                 Country = "USA",
                 IsPublished = true,
                 JobRoles =
                 [
                     CreateJobRole(
-                        "Platform Engineer",
-                        new DateOnly(2020, 6, 1),
-                        new DateOnly(2022, 3, 18),
-                        "Morgan Patel",
+                        "Software Engineering Consultant",
+                        new DateOnly(2024, 3, 1),
+                        new DateOnly(2025, 8, 31),
+                        null,
                         """
-                        Built shared backend components and supported product teams with data access and deployment tooling improvements.
+                        Contributed to a new ASP.NET MVC healthcare application for Humana Military, building MVC and Razor forms, supporting business logic, and collaborating with analysts and product owners.
+
+                        Supported production operations, issue triage, documentation review, escalation workflows, and Agile team delivery across multiple client engagements.
                         """,
-                        skills: ["Data Modeling", "Performance Tuning"],
-                        technologies: ["C#", "SQL Server"])
+                        skills: ["MVC Development", "Production Support", "Agile Delivery"],
+                        technologies: ["C#", "ASP.NET MVC", "Razor", "Web API", "Azure DevOps"])
+                ]
+            },
+            new Employer
+            {
+                Name = "TEKsystems",
+                City = null,
+                Region = null,
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Software Engineering Contractor (ORAU)",
+                        new DateOnly(2023, 5, 1),
+                        new DateOnly(2023, 8, 31),
+                        null,
+                        """
+                        Engineered new application features using .NET 7, C#, and ASP.NET MVC while collaborating in an Agile and Azure DevOps workflow.
+
+                        Debugged complex issues, reviewed CI/CD logs, and supported defect isolation across development and QA environments.
+                        """,
+                        skills: ["Debugging", "Agile Delivery", "CI/CD"],
+                        technologies: ["C#", ".NET 7", "ASP.NET MVC", "T-SQL", "Azure DevOps"]),
+                    CreateJobRole(
+                        "Senior Software Engineer Contractor (Availity)",
+                        new DateOnly(2022, 11, 1),
+                        new DateOnly(2023, 2, 28),
+                        null,
+                        """
+                        Led debugging and feature work for insurance-related ASP.NET MVC applications while partnering with analysts around EDI-aligned business requirements.
+
+                        Authored unit tests and delivered .NET 6 changes within an Azure DevOps and Agile delivery model.
+                        """,
+                        skills: ["Unit Testing", "EDI Domain Support", "Debugging"],
+                        technologies: ["C#", ".NET 6", "ASP.NET MVC", "Azure DevOps", "PL/SQL"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Robert Half",
+                City = "Pittsburgh",
+                Region = "PA",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Senior Software Engineer Consultant",
+                        new DateOnly(2021, 3, 1),
+                        new DateOnly(2022, 10, 31),
+                        null,
+                        """
+                        Developed and deployed RESTful APIs and ASP.NET MVC application features across multiple consulting engagements while adapting quickly to varied domains and client needs.
+
+                        Helped clients with planning, estimates, code reviews, and end-to-end software delivery using C#, .NET Core, Entity Framework, and Azure DevOps.
+                        """,
+                        skills: ["REST API Design", "Consulting", "Project Planning"],
+                        technologies: ["C#", ".NET Core", "ASP.NET MVC", "ASP.NET Web API", "Entity Framework Core", "Azure DevOps"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Delta Care RX",
+                City = "Pittsburgh",
+                Region = "PA",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Software Engineer",
+                        new DateOnly(2019, 9, 1),
+                        new DateOnly(2021, 1, 31),
+                        null,
+                        """
+                        Led architecture and development of a Vue.js patient identity-confirmation application and implemented secure REST APIs with JWT authentication.
+
+                        Managed MySQL data access, supported PDF-based document workflows, and improved reliability through debugging, testing, and custom JavaScript maintenance.
+                        """,
+                        skills: ["REST API Design", "JWT Authentication", "Frontend Development"],
+                        technologies: ["C#", "ASP.NET Core", "ASP.NET Web API", "Vue.js", "MySQL", "Entity Framework Core"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Sentara Health Care",
+                City = "Virginia Beach",
+                Region = "VA",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Software Engineer",
+                        new DateOnly(2018, 3, 1),
+                        new DateOnly(2019, 9, 30),
+                        null,
+                        """
+                        Designed RESTful APIs and middleware integrations, including Epic InterConnect transformation work and ETL processes for CSV and FTP-delivered healthcare data.
+
+                        Supported Swagger and AutoRest-based client generation, SQL Server data access, Jenkins and Azure DevOps delivery workflows, and 24/7 on-call production support.
+                        """,
+                        skills: ["ETL", "API Integration", "On-Call Support"],
+                        technologies: ["C#", "ASP.NET Core", "SQL Server", "Azure", "Swagger", "AutoRest", "Jenkins"])
+                ]
+            },
+            new Employer
+            {
+                Name = "IMPAQ International",
+                City = "Columbia",
+                Region = "MD",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Software Developer",
+                        new DateOnly(2017, 5, 1),
+                        new DateOnly(2018, 2, 28),
+                        null,
+                        """
+                        Maintained and enhanced ASP.NET applications, implemented new features, and authored unit tests to improve application robustness.
+
+                        Supported performance tuning, Jenkins-based release workflows, and Entity Framework-backed relational data access in a Team Foundation Server environment.
+                        """,
+                        skills: ["Application Maintenance", "Unit Testing", "Performance Tuning"],
+                        technologies: ["C#", "ASP.NET MVC", "Entity Framework", "SQL", "Jenkins"])
+                ]
+            },
+            new Employer
+            {
+                Name = "FEi Systems",
+                City = "Columbia",
+                Region = "MD",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Contract Developer",
+                        new DateOnly(2016, 9, 1),
+                        new DateOnly(2017, 2, 28),
+                        null,
+                        """
+                        Built and maintained PDF generation templates, contributed CSS and JavaScript UI improvements, and resolved software defects in established ASP.NET MVC applications.
+                        """,
+                        skills: ["PDF Generation", "UI Debugging", "Rapid Learning"],
+                        technologies: ["C#", "ASP.NET MVC", "CSS", "JavaScript", "RavenDB", "ABCpdf"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Revature",
+                City = "Reston",
+                Region = "VA",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Contract Developer",
+                        new DateOnly(2016, 2, 1),
+                        new DateOnly(2016, 8, 31),
+                        null,
+                        """
+                        Completed an intensive training program focused on emerging technologies and delivered projects using SQL Server, C#, .NET, ASP.NET MVC, and AngularJS within Agile teams.
+                        """,
+                        skills: ["Training", "Agile Delivery", "Form Development"],
+                        technologies: ["C#", "ASP.NET MVC", "ASP.NET Web Forms", "Entity Framework", "SQL Server", "AngularJS"])
+                ]
+            },
+            new Employer
+            {
+                Name = "MCS Valuations",
+                City = "Sandy",
+                Region = "UT",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Software Developer",
+                        new DateOnly(2015, 1, 1),
+                        new DateOnly(2015, 10, 31),
+                        null,
+                        """
+                        Maintained and upgraded the primary valuation application, implemented new SQL stored procedures, and supported rebranding-focused UI updates.
+
+                        Applied debugging and modernization work across legacy and newer Microsoft-stack technologies.
+                        """,
+                        skills: ["Debugging", "Stored Procedures", "UI Rebranding"],
+                        technologies: ["C#", "VB.NET", "VB6", "SQL Server", "Classic ASP"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Zycamore LLC",
+                City = "Provo",
+                Region = "UT",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Software Developer",
+                        new DateOnly(2014, 4, 1),
+                        new DateOnly(2014, 12, 31),
+                        null,
+                        """
+                        Built SQL generation scripts, C# file-generation utilities, and ASP.NET MVC form validation features while also supporting Windows Server and IIS setup work.
+                        """,
+                        skills: ["Server Provisioning", "Form Validation", "Automation"],
+                        technologies: ["C#", "ASP.NET MVC", "SQL Server", "IIS", "Windows Server"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Ocean Avenue",
+                City = "South Jordan",
+                Region = "UT",
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Junior Software Developer",
+                        new DateOnly(2013, 3, 1),
+                        new DateOnly(2013, 11, 30),
+                        null,
+                        """
+                        Published code to development and production environments for a Sitefinity-based ASP.NET site, implemented backend C# business logic, and enhanced client-side behavior with JavaScript and jQuery.
+
+                        Added AJAX features, SQL reporting support, and integrations with third-party OData web services.
+                        """,
+                        skills: ["Release Support", "OData Integration", "AJAX"],
+                        technologies: ["C#", "ASP.NET", "Sitefinity", "JavaScript", "jQuery", "SQL Server"])
+                ]
+            },
+            new Employer
+            {
+                Name = "Rubio's",
+                City = null,
+                Region = null,
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Intern Developer",
+                        new DateOnly(2012, 10, 1),
+                        new DateOnly(2012, 12, 31),
+                        null,
+                        """
+                        Supported an enterprise reporting application, implemented C# business rules in an ASP.NET application, and participated in daily Scrum collaboration.
+                        """,
+                        skills: ["Business Rules", "Enterprise Reporting", "Scrum"],
+                        technologies: ["C#", "ASP.NET", "Team Foundation Server"])
+                ]
+            },
+            new Employer
+            {
+                Name = "TopVue Defense",
+                City = null,
+                Region = null,
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Intern Developer",
+                        new DateOnly(2012, 10, 1),
+                        new DateOnly(2012, 12, 31),
+                        null,
+                        """
+                        Developed enterprise application features with PL/SQL, ASP.NET, C#, and JavaScript while collaborating through Team Foundation Server and daily Scrum meetings.
+                        """,
+                        skills: ["PL/SQL Development", "Enterprise Collaboration", "Scrum"],
+                        technologies: ["PL/SQL", "C#", "ASP.NET", "JavaScript"])
+                ]
+            },
+            new Employer
+            {
+                Name = "GTECH",
+                City = null,
+                Region = null,
+                Country = "USA",
+                IsPublished = true,
+                JobRoles =
+                [
+                    CreateJobRole(
+                        "Intern Developer",
+                        new DateOnly(2012, 6, 1),
+                        new DateOnly(2012, 9, 30),
+                        null,
+                        """
+                        Supported a lottery-simulation enterprise project by generating automated test cases and building Java utilities for XML parsing and file I/O workflows.
+                        """,
+                        skills: ["Automated Testing", "XML Parsing", "File I/O"],
+                        technologies: ["Java", "XML", "Eclipse"])
                 ]
             }
         ];

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -470,6 +470,13 @@
     gap: 0.7rem;
 }
 
+.resume-filter-chip-list,
+.resume-highlight-preview {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
 .resume-link-card,
 .resume-action-card {
     padding: 1rem;
@@ -496,6 +503,32 @@
 
 .resume-action-copy .meta-label {
     color: #d7e2f1;
+}
+
+.resume-filter-chip {
+    min-height: 2.35rem;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid rgba(111, 137, 171, 0.18);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #dce7f5;
+    font-size: 0.84rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.resume-filter-chip:hover {
+    transform: translateY(-1px);
+    border-color: rgba(126, 233, 255, 0.34);
+}
+
+.resume-filter-chip.selected {
+    border-color: rgba(245, 183, 48, 0.42);
+    background:
+        linear-gradient(135deg, rgba(245, 183, 48, 0.18), rgba(255, 255, 255, 0.08));
+    color: #fff2cc;
+    box-shadow: inset 0 0 0 1px rgba(255, 223, 143, 0.12);
 }
 
 .resume-action-button {
@@ -568,6 +601,95 @@
 
 .resume-highlight-group {
     gap: 0.55rem;
+}
+
+.resume-highlight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 0.7rem;
+}
+
+.resume-highlight-card {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.95rem 1rem;
+    border: 1px solid rgba(111, 137, 171, 0.16);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.resume-highlight-card.skill {
+    border-color: rgba(245, 183, 48, 0.24);
+    background:
+        linear-gradient(180deg, rgba(255, 216, 111, 0.12), rgba(255, 255, 255, 0.03));
+}
+
+.resume-highlight-card.technology {
+    border-color: rgba(126, 233, 255, 0.18);
+    background:
+        linear-gradient(180deg, rgba(99, 222, 255, 0.12), rgba(255, 255, 255, 0.03));
+}
+
+.resume-highlight-card p,
+.resume-highlight-card strong {
+    margin: 0;
+}
+
+.resume-highlight-card strong {
+    color: #fff7e8;
+}
+
+.resume-highlight-card p {
+    color: rgba(219, 230, 243, 0.82);
+}
+
+.resume-highlight-pill {
+    display: inline-grid;
+    gap: 0.15rem;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid rgba(111, 137, 171, 0.18);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.resume-highlight-pill strong,
+.resume-highlight-pill span {
+    margin: 0;
+}
+
+.resume-highlight-pill strong {
+    color: #fff7e8;
+    font-size: 0.84rem;
+}
+
+.resume-highlight-pill span {
+    color: rgba(219, 230, 243, 0.78);
+    font-size: 0.76rem;
+}
+
+.resume-highlight-pill.skill {
+    border-color: rgba(245, 183, 48, 0.24);
+}
+
+.resume-highlight-pill.technology {
+    border-color: rgba(126, 233, 255, 0.2);
+}
+
+.resume-page .tag.promoted {
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow:
+        0 0 0 1px rgba(255, 255, 255, 0.04),
+        0 10px 18px rgba(7, 16, 30, 0.18);
+}
+
+.resume-page .tag.skill.promoted {
+    background: rgba(245, 183, 48, 0.28);
+    color: #fff1bf;
+}
+
+.resume-page .tag.technology.promoted {
+    background: rgba(126, 233, 255, 0.14);
+    color: #f2fbff;
 }
 
 .resume-shell-note {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -379,7 +379,7 @@ describe('App', () => {
         expect(await screen.findByRole('heading', { name: 'Bronze Loft' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Resume' })).toHaveAttribute('aria-current', 'page');
         expect(screen.getAllByText('Open to senior full-stack roles')).toHaveLength(2);
-        expect(screen.getByText('Senior Software Engineer')).toBeInTheDocument();
+        expect(await screen.findByText('Senior Software Engineer')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /bronze@example\.dev/i })).toHaveAttribute('href', 'mailto:bronze@example.dev');
         expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
         expect(screen.getByRole('button', { name: 'Full history' })).toHaveAttribute('aria-pressed', 'true');

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -382,8 +382,12 @@ describe('App', () => {
         expect(screen.getByText('Senior Software Engineer')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /bronze@example\.dev/i })).toHaveAttribute('href', 'mailto:bronze@example.dev');
         expect(screen.getByRole('link', { name: /GitHub.*@darkdhamon/i })).toHaveAttribute('href', 'https://github.com/darkdhamon');
-        expect(screen.getByRole('button', { name: 'Filter Resume' })).toBeDisabled();
-        expect(screen.getByRole('button', { name: 'Highlight Skills' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Full history' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'Last 10 years' })).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByRole('button', { name: 'Last 5 years' })).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByRole('button', { name: 'All employers' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'Top 3' })).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByRole('button', { name: 'Top 5' })).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Open Static Resume' })).toBeDisabled();
     });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -204,6 +204,8 @@ describe('ResumePage', () => {
     });
 
     it('filters the resume by time window and recent employer count', () => {
+        vi.setSystemTime(new Date('2026-05-24T12:00:00Z'));
+
         mockUseWorkHistory.mockReturnValue({
             employers: [
                 createEmployer(1, {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Employer, PortfolioProfile } from '../../app/types';
 import { ResumePage } from './ResumePage';
@@ -139,7 +139,7 @@ describe('ResumePage', () => {
         expect(screen.getByText('Public contact and social links will appear here once the portfolio profile is configured.')).toBeInTheDocument();
         expect(screen.getByText('Published work history will appear here once employer and job-role records are available.')).toBeInTheDocument();
         expect(screen.queryByRole('heading', { name: 'Positioning for recruiters and hiring teams.' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('heading', { name: 'Core skills and technologies.' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Highlighted skills and technologies.' })).not.toBeInTheDocument();
     });
 
     it('renders structured summary, skill highlights, and full experience history', () => {
@@ -182,11 +182,12 @@ describe('ResumePage', () => {
         expect(within(summaryPanel as HTMLElement).getByText('Full-stack engineer focused on dependable delivery.')).toBeInTheDocument();
         expect(within(summaryPanel as HTMLElement).getByText('Remote-friendly, collaborative, and comfortable owning delivery from API to UI polish.')).toBeInTheDocument();
 
-        expect(screen.getByRole('heading', { name: 'Core skills and technologies.' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Highlighted skills and technologies.' })).toBeInTheDocument();
         expect(screen.getByLabelText('Resume skills')).toHaveTextContent('Skill 1');
         expect(screen.getByLabelText('Resume skills')).toHaveTextContent('Architecture');
         expect(screen.getByLabelText('Resume technologies')).toHaveTextContent('.NET 10');
         expect(screen.getByLabelText('Resume technologies')).toHaveTextContent('React');
+        expect(screen.getAllByText('Appears in 1 visible role.').length).toBeGreaterThan(0);
 
         const experiencePanel = screen.getByRole('heading', { name: 'Condensed work history.' }).closest('article');
         expect(experiencePanel).not.toBeNull();
@@ -200,6 +201,88 @@ describe('ResumePage', () => {
         expect(within(experiencePanel as HTMLElement).getByText('Feb 2019 to Dec 2023')).toHaveAttribute('title', 'Time at Employer 2: 4 years, 11 months');
         expect(within(experiencePanel as HTMLElement).getByText('May 2021 to Dec 2023')).toHaveAttribute('title', 'Time in role: 2 years, 8 months');
         expect(within(experiencePanel as HTMLElement).getByText('Feb 2019 to May 2021')).toHaveAttribute('title', 'Time in role: 2 years, 4 months');
+    });
+
+    it('filters the resume by time window and recent employer count', () => {
+        mockUseWorkHistory.mockReturnValue({
+            employers: [
+                createEmployer(1, {
+                    name: 'Current Employer',
+                    jobRoles: [
+                        {
+                            role: 'Staff Engineer',
+                            startDate: '2024-02-01',
+                            endDate: null,
+                            descriptionMarkdown: 'Owning platform and delivery work.',
+                            skills: ['Leadership'],
+                            technologies: ['React']
+                        }
+                    ]
+                }),
+                createEmployer(2, {
+                    name: 'Recent Employer',
+                    jobRoles: [
+                        {
+                            role: 'Senior Engineer',
+                            startDate: '2022-03-01',
+                            endDate: '2024-01-15',
+                            descriptionMarkdown: 'Drove modernization initiatives.',
+                            skills: ['Architecture'],
+                            technologies: ['.NET 10']
+                        }
+                    ]
+                }),
+                createEmployer(3, {
+                    name: 'Bridge Employer',
+                    jobRoles: [
+                        {
+                            role: 'Engineer',
+                            startDate: '2020-01-01',
+                            endDate: '2021-08-15',
+                            descriptionMarkdown: 'Supported platform transitions.',
+                            skills: ['Testing'],
+                            technologies: ['Azure']
+                        }
+                    ]
+                }),
+                createEmployer(4, {
+                    name: 'Legacy Employer',
+                    jobRoles: [
+                        {
+                            role: 'Analyst',
+                            startDate: '2015-01-01',
+                            endDate: '2017-12-20',
+                            descriptionMarkdown: 'Early delivery work.',
+                            skills: ['Support'],
+                            technologies: ['SQL Server']
+                        }
+                    ]
+                })
+            ],
+            isLoading: false,
+            error: null
+        });
+
+        render(<ResumePage />);
+
+        expect(screen.getByText('Current Employer')).toBeInTheDocument();
+        expect(screen.getByText('Recent Employer')).toBeInTheDocument();
+        expect(screen.getByText('Bridge Employer')).toBeInTheDocument();
+        expect(screen.getByText('Legacy Employer')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Last 5 years' }));
+
+        expect(screen.getByText('Current Employer')).toBeInTheDocument();
+        expect(screen.getByText('Recent Employer')).toBeInTheDocument();
+        expect(screen.getByText('Bridge Employer')).toBeInTheDocument();
+        expect(screen.queryByText('Legacy Employer')).not.toBeInTheDocument();
+        expect(screen.getByText('3 roles across 3 employers')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Top 3' }));
+
+        expect(screen.getByRole('button', { name: 'Top 3' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByText('Visible Employers')).toBeInTheDocument();
+        expect(screen.getByText('Active Filters')).toBeInTheDocument();
     });
 
     it('avoids duplicate key warnings when role titles and start dates repeat', () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { JobRole } from '../../app/types';
 import { formatProjectDates } from '../../appSupport';
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
@@ -14,6 +15,66 @@ interface ResumeRoleEntry {
     dateValue: ResumeDateValue;
 }
 
+interface ResumeHighlight {
+    count: number;
+    label: string;
+}
+
+type ResumeTimeFilterKey = 'all' | 'last10Years' | 'last5Years';
+type ResumeEmployerLimitKey = 'all' | '3' | '5';
+
+const resumeTimeFilters: ReadonlyArray<{
+    description: string;
+    key: ResumeTimeFilterKey;
+    label: string;
+    years: number | null;
+}> = [
+    {
+        key: 'all',
+        label: 'Full history',
+        years: null,
+        description: 'Every published role and employer.'
+    },
+    {
+        key: 'last10Years',
+        label: 'Last 10 years',
+        years: 10,
+        description: 'Roles active within the last decade.'
+    },
+    {
+        key: 'last5Years',
+        label: 'Last 5 years',
+        years: 5,
+        description: 'Recent experience for fast recruiter scans.'
+    }
+];
+
+const resumeEmployerLimits: ReadonlyArray<{
+    description: string;
+    key: ResumeEmployerLimitKey;
+    label: string;
+    limit: number | null;
+}> = [
+    {
+        key: 'all',
+        label: 'All employers',
+        limit: null,
+        description: 'Show every employer in the active time window.'
+    },
+    {
+        key: '3',
+        label: 'Top 3',
+        limit: 3,
+        description: 'Focus on the three most recent employers.'
+    },
+    {
+        key: '5',
+        label: 'Top 5',
+        limit: 5,
+        description: 'Keep the resume compact without hiding too much depth.'
+    }
+];
+
 function getRoleCount(employerCount: number, roleCount: number) {
     return `${roleCount} role${roleCount === 1 ? '' : 's'} across ${employerCount} employer${employerCount === 1 ? '' : 's'}`;
 }
@@ -28,20 +89,6 @@ function getResumeContactHref(value: string) {
     }
 
     return '';
-}
-
-function getOrderedUniqueValues(values: string[]) {
-    const seen = new Set<string>();
-
-    return values.filter(value => {
-        const trimmedValue = value.trim();
-        if (!trimmedValue || seen.has(trimmedValue)) {
-            return false;
-        }
-
-        seen.add(trimmedValue);
-        return true;
-    });
 }
 
 function getLocationLabel(city?: string | null, region?: string | null) {
@@ -65,6 +112,11 @@ function getMonthDistance(startDate: string, endDate?: string | null) {
     };
 
     return Math.max(0, ((end.year - start.year) * 12) + (end.month - start.month) + 1);
+}
+
+function getMonthIndex(value: string) {
+    const { year, month } = getDateMonthValue(value);
+    return (year * 12) + month;
 }
 
 function formatDurationLabel(totalMonths: number) {
@@ -148,7 +200,96 @@ function buildResumeRoleEntries(jobRoles: JobRole[]) {
     });
 }
 
+function roleMatchesTimeFilter(jobRole: JobRole, cutoffDate: Date | null, currentDate: Date) {
+    if (!cutoffDate) {
+        return true;
+    }
+
+    const roleEndDate = jobRole.endDate ? new Date(jobRole.endDate) : currentDate;
+    return roleEndDate >= cutoffDate;
+}
+
+function getEmployerRecencyScore(jobRoles: JobRole[], currentMonthIndex: number) {
+    return jobRoles.reduce((highestScore, jobRole) => {
+        const roleScore = jobRole.endDate ? getMonthIndex(jobRole.endDate) : currentMonthIndex;
+        return Math.max(highestScore, roleScore);
+    }, 0);
+}
+
+function buildResumeHighlights(
+    roleEntries: Array<{ jobRole: JobRole }>,
+    getValues: (jobRole: JobRole) => string[],
+    limit: number
+) {
+    const counts = new Map<string, { count: number; firstSeenAt: number }>();
+
+    roleEntries.forEach((entry, entryIndex) => {
+        getValues(entry.jobRole).forEach(value => {
+            const trimmedValue = value.trim();
+            if (!trimmedValue) {
+                return;
+            }
+
+            const currentValue = counts.get(trimmedValue);
+            if (currentValue) {
+                currentValue.count += 1;
+                return;
+            }
+
+            counts.set(trimmedValue, {
+                count: 1,
+                firstSeenAt: entryIndex
+            });
+        });
+    });
+
+    return [...counts.entries()]
+        .sort((left, right) => {
+            if (right[1].count !== left[1].count) {
+                return right[1].count - left[1].count;
+            }
+
+            if (left[1].firstSeenAt !== right[1].firstSeenAt) {
+                return left[1].firstSeenAt - right[1].firstSeenAt;
+            }
+
+            return left[0].localeCompare(right[0]);
+        })
+        .slice(0, limit)
+        .map(([label, metadata]) => ({
+            label,
+            count: metadata.count
+        } satisfies ResumeHighlight));
+}
+
+function getResumeViewSummary(
+    selectedTimeFilter: { description: string; key: ResumeTimeFilterKey; label: string },
+    selectedEmployerLimit: { description: string; key: ResumeEmployerLimitKey; label: string; limit: number | null },
+    employerCount: number,
+    roleCount: number,
+    totalRoleCount: number
+) {
+    if (totalRoleCount === 0) {
+        return 'Publish public profile and work history records to turn this shell into a complete recruiter-facing resume.';
+    }
+
+    if (roleCount === 0) {
+        return 'No published roles match the active resume filters yet. Expand the time window or increase the employer count to bring older experience back into view.';
+    }
+
+    const timeSummary = selectedTimeFilter.key === 'all'
+        ? 'Showing full published history.'
+        : `Showing ${selectedTimeFilter.label.toLowerCase()}.`;
+    const employerSummary = selectedEmployerLimit.limit === null
+        ? 'All matching employers remain visible.'
+        : `Limited to the ${employerCount} most recent matching employer${employerCount === 1 ? '' : 's'}.`;
+
+    return `${timeSummary} ${employerSummary} ${getRoleCount(employerCount, roleCount)} remain in view.`;
+}
+
 export function ResumePage() {
+    const [selectedTimeFilterKey, setSelectedTimeFilterKey] = useState<ResumeTimeFilterKey>('all');
+    const [selectedEmployerLimitKey, setSelectedEmployerLimitKey] = useState<ResumeEmployerLimitKey>('all');
     const {
         profile,
         isLoading: isProfileLoading,
@@ -161,27 +302,64 @@ export function ResumePage() {
         error: workHistoryError
     } = useWorkHistory();
 
+    const currentDate = new Date();
+    const currentMonthIndex = (currentDate.getFullYear() * 12) + currentDate.getMonth() + 1;
+    const selectedTimeFilter = resumeTimeFilters.find(filter => filter.key === selectedTimeFilterKey) ?? resumeTimeFilters[0];
+    const selectedEmployerLimit = resumeEmployerLimits.find(limit => limit.key === selectedEmployerLimitKey) ?? resumeEmployerLimits[0];
+    const cutoffDate = selectedTimeFilter.years === null
+        ? null
+        : new Date(currentDate.getFullYear() - selectedTimeFilter.years, currentDate.getMonth(), currentDate.getDate());
+    const employersInTimeView = employers
+        .map(employer => ({
+            ...employer,
+            jobRoles: employer.jobRoles.filter(jobRole => roleMatchesTimeFilter(jobRole, cutoffDate, currentDate))
+        }))
+        .filter(employer => employer.jobRoles.length > 0)
+        .sort((left, right) => getEmployerRecencyScore(right.jobRoles, currentMonthIndex) - getEmployerRecencyScore(left.jobRoles, currentMonthIndex));
+    const filteredEmployers = selectedEmployerLimit.limit === null
+        ? employersInTimeView
+        : employersInTimeView.slice(0, selectedEmployerLimit.limit);
     const roleRecords = employers.flatMap(employer => employer.jobRoles.map(jobRole => ({
         employer,
         jobRole
     })));
-    const roleCount = roleRecords.length;
-    const primaryRole = roleRecords.find(record => record.jobRole.role.trim().length > 0)?.jobRole;
-    const location = employers
+    const filteredRoleRecords = filteredEmployers.flatMap(employer => employer.jobRoles.map(jobRole => ({
+        employer,
+        jobRole
+    })));
+    const totalEmployerCount = employers.length;
+    const totalRoleCount = roleRecords.length;
+    const filteredRoleCount = filteredRoleRecords.length;
+    const primaryRole = filteredRoleRecords.find(record => record.jobRole.role.trim().length > 0)?.jobRole
+        ?? roleRecords.find(record => record.jobRole.role.trim().length > 0)?.jobRole;
+    const location = filteredEmployers
         .map(employer => getLocationLabel(employer.city, employer.region))
-        .find(Boolean);
+        .find(Boolean)
+        ?? employers
+            .map(employer => getLocationLabel(employer.city, employer.region))
+            .find(Boolean);
     const contactMethods = (profile?.contactMethods ?? []).slice(0, 3);
     const socialLinks = (profile?.socialLinks ?? []).slice(0, 2);
     const contactChannelCount = contactMethods.length + socialLinks.length;
     const summaryParagraphs = [profile?.contactIntro?.trim(), profile?.availabilitySummary?.trim()].filter(
         (value): value is string => Boolean(value && value.length > 0)
     );
-    const skillHighlights = getOrderedUniqueValues(roleRecords.flatMap(record => record.jobRole.skills)).slice(0, 8);
-    const technologyHighlights = getOrderedUniqueValues(roleRecords.flatMap(record => record.jobRole.technologies)).slice(0, 8);
+    const skillHighlights = buildResumeHighlights(filteredRoleRecords, jobRole => jobRole.skills, 6);
+    const technologyHighlights = buildResumeHighlights(filteredRoleRecords, jobRole => jobRole.technologies, 6);
+    const highlightedSkillSet = new Set(skillHighlights.map(highlight => highlight.label));
+    const highlightedTechnologySet = new Set(technologyHighlights.map(highlight => highlight.label));
     const hasSummarySection = Boolean(profile?.contactHeadline?.trim() || profile?.availabilityHeadline?.trim() || summaryParagraphs.length > 0);
     const hasSkillsSection = skillHighlights.length > 0 || technologyHighlights.length > 0;
     const isLoading = isProfileLoading || isWorkHistoryLoading;
     const errors = [profileError, workHistoryError].filter(Boolean);
+    const activeFilterCount = (selectedTimeFilter.key === 'all' ? 0 : 1) + (selectedEmployerLimit.key === 'all' ? 0 : 1);
+    const resumeViewSummary = getResumeViewSummary(
+        selectedTimeFilter,
+        selectedEmployerLimit,
+        filteredEmployers.length,
+        filteredRoleCount,
+        totalRoleCount
+    );
 
     return (
         <main className="resume-page">
@@ -208,26 +386,26 @@ export function ResumePage() {
                 <div className="resume-hero-meta">
                     <section className="resume-callout-card" aria-label="Resume summary">
                         <span className="stat-label">Resume Snapshot</span>
-                        <strong>{roleCount > 0 ? getRoleCount(employers.length, roleCount) : 'Waiting for published resume data'}</strong>
+                        <strong>{filteredRoleCount > 0 ? getRoleCount(filteredEmployers.length, filteredRoleCount) : totalRoleCount > 0 ? 'No roles match the current resume filters' : 'Waiting for published resume data'}</strong>
                         <p>
                             {profile?.availabilityHeadline?.trim()
                                 ? profile.availabilityHeadline
-                                : 'Publish public profile and work history records to turn this shell into a complete recruiter-facing resume.'}
+                                : resumeViewSummary}
                         </p>
                     </section>
 
                     <div className="hero-stats" aria-label="Resume summary stats">
                         <div className="stat-card">
-                            <span className="stat-label">Employers</span>
-                            <strong>{employers.length}</strong>
+                            <span className="stat-label">{activeFilterCount > 0 ? 'Visible Employers' : 'Employers'}</span>
+                            <strong>{filteredEmployers.length}</strong>
                         </div>
                         <div className="stat-card">
-                            <span className="stat-label">Roles</span>
-                            <strong>{roleCount}</strong>
+                            <span className="stat-label">{activeFilterCount > 0 ? 'Visible Roles' : 'Roles'}</span>
+                            <strong>{filteredRoleCount}</strong>
                         </div>
                         <div className="stat-card">
-                            <span className="stat-label">Contact Channels</span>
-                            <strong>{contactChannelCount}</strong>
+                            <span className="stat-label">{activeFilterCount > 0 ? 'Active Filters' : 'Contact Channels'}</span>
+                            <strong>{activeFilterCount > 0 ? activeFilterCount : contactChannelCount}</strong>
                         </div>
                     </div>
                 </div>
@@ -235,37 +413,73 @@ export function ResumePage() {
 
             <section className="resume-action-area">
                 <article className="resume-panel resume-action-panel">
-                    <p className="eyebrow">Resume Actions</p>
+                    <p className="eyebrow">Resume Controls</p>
                     <div className="resume-action-grid">
                         <div className="resume-action-card">
                             <div className="resume-action-copy">
-                                <span className="meta-label">Resume Filters</span>
-                                <span className="resume-action-note">Issue #87</span>
+                                <span className="meta-label">Time Window</span>
+                                <span className="resume-action-note">{selectedTimeFilter.description}</span>
                             </div>
-                            <button
-                                className="resume-action-button"
-                                type="button"
-                                disabled
-                                aria-disabled="true"
-                                aria-label="Filter Resume">
-                                <span>Filter Resume</span>
-                                <span className="coming-soon-pill">Coming Soon</span>
-                            </button>
+                            <div className="resume-filter-chip-list" role="group" aria-label="Resume time filters">
+                                {resumeTimeFilters.map(filter => {
+                                    const isSelected = filter.key === selectedTimeFilter.key;
+                                    return (
+                                        <button
+                                            key={filter.key}
+                                            className={`resume-filter-chip${isSelected ? ' selected' : ''}`}
+                                            type="button"
+                                            onClick={() => setSelectedTimeFilterKey(filter.key)}
+                                            aria-pressed={isSelected}>
+                                            {filter.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
                         </div>
                         <div className="resume-action-card">
                             <div className="resume-action-copy">
-                                <span className="meta-label">Skill Highlights</span>
+                                <span className="meta-label">Recent Employers</span>
+                                <span className="resume-action-note">{selectedEmployerLimit.description}</span>
+                            </div>
+                            <div className="resume-filter-chip-list" role="group" aria-label="Resume employer filters">
+                                {resumeEmployerLimits.map(limit => {
+                                    const isSelected = limit.key === selectedEmployerLimit.key;
+                                    return (
+                                        <button
+                                            key={limit.key}
+                                            className={`resume-filter-chip${isSelected ? ' selected' : ''}`}
+                                            type="button"
+                                            onClick={() => setSelectedEmployerLimitKey(limit.key)}
+                                            aria-pressed={isSelected}>
+                                            {limit.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                        <div className="resume-action-card">
+                            <div className="resume-action-copy">
+                                <span className="meta-label">Highlight Preview</span>
                                 <span className="resume-action-note">Issue #87</span>
                             </div>
-                            <button
-                                className="resume-action-button"
-                                type="button"
-                                disabled
-                                aria-disabled="true"
-                                aria-label="Highlight Skills">
-                                <span>Highlight Skills</span>
-                                <span className="coming-soon-pill">Coming Soon</span>
-                            </button>
+                            {hasSkillsSection ? (
+                                <div className="resume-highlight-preview" aria-label="Resume highlight preview">
+                                    {skillHighlights.slice(0, 3).map(highlight => (
+                                        <span key={`skill-${highlight.label}`} className="resume-highlight-pill skill">
+                                            <strong>{highlight.label}</strong>
+                                            <span>{highlight.count} role{highlight.count === 1 ? '' : 's'}</span>
+                                        </span>
+                                    ))}
+                                    {technologyHighlights.slice(0, 3).map(highlight => (
+                                        <span key={`technology-${highlight.label}`} className="resume-highlight-pill technology">
+                                            <strong>{highlight.label}</strong>
+                                            <span>{highlight.count} role{highlight.count === 1 ? '' : 's'}</span>
+                                        </span>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p>Visible skills and technologies will promote here as resume data becomes available.</p>
+                            )}
                         </div>
                         <div className="resume-action-card">
                             <div className="resume-action-copy">
@@ -387,9 +601,9 @@ export function ResumePage() {
                         <h2>Condensed work history.</h2>
                     </div>
 
-                    {employers.length > 0 ? (
+                    {filteredEmployers.length > 0 ? (
                         <div className="resume-experience-list">
-                            {employers.map(employer => {
+                            {filteredEmployers.map(employer => {
                                 const employerLocation = getLocationLabel(employer.city, employer.region);
                                 const employerDateValue = getEmployerDateValue(employer.name, employer.jobRoles);
                                 const roleEntries = buildResumeRoleEntries(employer.jobRoles);
@@ -432,7 +646,7 @@ export function ResumePage() {
                                                         {jobRole.skills.length > 0 ? (
                                                             <div className="tag-group" aria-label={`${jobRole.role} skills`}>
                                                                 {jobRole.skills.map(skill => (
-                                                                    <span key={skill} className="tag skill">{skill}</span>
+                                                                    <span key={skill} className={`tag skill${highlightedSkillSet.has(skill) ? ' promoted' : ''}`}>{skill}</span>
                                                                 ))}
                                                             </div>
                                                         ) : null}
@@ -440,7 +654,7 @@ export function ResumePage() {
                                                         {jobRole.technologies.length > 0 ? (
                                                             <div className="tag-group secondary" aria-label={`${jobRole.role} technologies`}>
                                                                 {jobRole.technologies.map(technology => (
-                                                                    <span key={technology} className="tag technology">{technology}</span>
+                                                                    <span key={technology} className={`tag technology${highlightedTechnologySet.has(technology) ? ' promoted' : ''}`}>{technology}</span>
                                                                 ))}
                                                             </div>
                                                         ) : null}
@@ -454,7 +668,9 @@ export function ResumePage() {
                         </div>
                     ) : (
                         <p className="secondary-copy">
-                            Published work history will appear here once employer and job-role records are available.
+                            {totalEmployerCount > 0
+                                ? 'No published roles match the current resume filters. Expand the time window or increase the employer count to bring older experience back into view.'
+                                : 'Published work history will appear here once employer and job-role records are available.'}
                         </p>
                     )}
                 </article>
@@ -463,16 +679,19 @@ export function ResumePage() {
                     <article className="resume-panel">
                         <div className="resume-panel-heading">
                             <p className="eyebrow">Skills</p>
-                            <h2>Core skills and technologies.</h2>
+                            <h2>Highlighted skills and technologies.</h2>
                         </div>
 
                         <div className="resume-highlight-list">
                             {skillHighlights.length > 0 ? (
                                 <section className="resume-highlight-group">
                                     <span className="meta-label">Skills</span>
-                                    <div className="tag-group" aria-label="Resume skills">
+                                    <div className="resume-highlight-grid" aria-label="Resume skills">
                                         {skillHighlights.map(skill => (
-                                            <span key={skill} className="tag skill">{skill}</span>
+                                            <article key={skill.label} className="resume-highlight-card skill">
+                                                <strong>{skill.label}</strong>
+                                                <p>Appears in {skill.count} visible role{skill.count === 1 ? '' : 's'}.</p>
+                                            </article>
                                         ))}
                                     </div>
                                 </section>
@@ -481,9 +700,12 @@ export function ResumePage() {
                             {technologyHighlights.length > 0 ? (
                                 <section className="resume-highlight-group">
                                     <span className="meta-label">Technologies</span>
-                                    <div className="tag-group secondary" aria-label="Resume technologies">
+                                    <div className="resume-highlight-grid" aria-label="Resume technologies">
                                         {technologyHighlights.map(technology => (
-                                            <span key={technology} className="tag technology">{technology}</span>
+                                            <article key={technology.label} className="resume-highlight-card technology">
+                                                <strong>{technology.label}</strong>
+                                                <p>Appears in {technology.count} visible role{technology.count === 1 ? '' : 's'}.</p>
+                                            </article>
                                         ))}
                                     </div>
                                 </section>

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -119,6 +119,13 @@ function getMonthIndex(value: string) {
     return (year * 12) + month;
 }
 
+function formatDateKey(date: Date) {
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
 function formatDurationLabel(totalMonths: number) {
     const years = Math.floor(totalMonths / 12);
     const months = totalMonths % 12;
@@ -200,13 +207,13 @@ function buildResumeRoleEntries(jobRoles: JobRole[]) {
     });
 }
 
-function roleMatchesTimeFilter(jobRole: JobRole, cutoffDate: Date | null, currentDate: Date) {
-    if (!cutoffDate) {
+function roleMatchesTimeFilter(jobRole: JobRole, cutoffDateKey: string | null, currentDateKey: string) {
+    if (!cutoffDateKey) {
         return true;
     }
 
-    const roleEndDate = jobRole.endDate ? new Date(jobRole.endDate) : currentDate;
-    return roleEndDate >= cutoffDate;
+    const roleEndDateKey = jobRole.endDate ?? currentDateKey;
+    return roleEndDateKey >= cutoffDateKey;
 }
 
 function getEmployerRecencyScore(jobRoles: JobRole[], currentMonthIndex: number) {
@@ -309,10 +316,12 @@ export function ResumePage() {
     const cutoffDate = selectedTimeFilter.years === null
         ? null
         : new Date(currentDate.getFullYear() - selectedTimeFilter.years, currentDate.getMonth(), currentDate.getDate());
+    const cutoffDateKey = cutoffDate ? formatDateKey(cutoffDate) : null;
+    const currentDateKey = formatDateKey(currentDate);
     const employersInTimeView = employers
         .map(employer => ({
             ...employer,
-            jobRoles: employer.jobRoles.filter(jobRole => roleMatchesTimeFilter(jobRole, cutoffDate, currentDate))
+            jobRoles: employer.jobRoles.filter(jobRole => roleMatchesTimeFilter(jobRole, cutoffDateKey, currentDateKey))
         }))
         .filter(employer => employer.jobRoles.length > 0)
         .sort((left, right) => getEmployerRecencyScore(right.jobRoles, currentMonthIndex) - getEmployerRecencyScore(left.jobRoles, currentMonthIndex));


### PR DESCRIPTION
## Summary
- add recruiter-focused resume time-window and recent-employer filters on the public resume page
- filter the structured experience view and summary stats from the active presets
- promote visible skills and technologies with stronger highlight treatment and resume-page tests

## Why
Issue #87 calls for limited MVP resume filtering and stronger skill scanability without turning the page into an exploratory query builder.

## Validation
- npm test -- src/features/resume/ResumePage.test.tsx
- npm run build
- npm run lint
