### PR TITLE
[codex] Style admin workspace action links

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -955,6 +955,35 @@
     font-size: 0.82rem;
 }
 
+.admin-action-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.85rem;
+    padding: 0.45rem 1rem;
+    border: 1px solid rgba(245, 183, 48, 0.78);
+    border-radius: 999px;
+    background:
+        linear-gradient(180deg, rgba(245, 183, 48, 0.96), rgba(232, 165, 33, 0.96));
+    color: #10233d;
+    font-weight: 800;
+    text-decoration: none;
+    line-height: 1.2;
+    transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
+    box-shadow: 0 10px 24px rgba(10, 25, 47, 0.22);
+}
+
+.admin-action-link:hover {
+    transform: translateY(-1px);
+    filter: brightness(1.03);
+    box-shadow: 0 14px 26px rgba(10, 25, 47, 0.28);
+}
+
+.admin-action-link:focus-visible {
+    outline: 0.18rem solid rgba(126, 233, 255, 0.32);
+    outline-offset: 0.14rem;
+}
+
 .admin-route-pill {
     display: inline-flex;
     align-items: center;

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/AdminWorkspacePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/AdminWorkspacePage.tsx
@@ -101,7 +101,7 @@ export function AdminWorkspacePage({
                         <p className="eyebrow">Session</p>
                         <p>Account maintenance stays available from the same admin surface while the content tools grow.</p>
                         <InternalLink
-                            className="primary-link"
+                            className="admin-action-link"
                             href="/admin/account"
                             onNavigate={onNavigate}
                             preserveScroll={true}>
@@ -120,7 +120,7 @@ export function AdminWorkspacePage({
                                     <p>{section.summary}</p>
                                     <p className="admin-section-meta">Next tracked work: {section.issueReferences}</p>
                                     <InternalLink
-                                        className="primary-link"
+                                        className="admin-action-link"
                                         href={section.href}
                                         onNavigate={onNavigate}
                                         preserveScroll={true}>
@@ -141,7 +141,7 @@ export function AdminWorkspacePage({
                             </ul>
                             <p className="admin-section-meta">Tracked issues: {currentSection.issueReferences}</p>
                             <InternalLink
-                                className="primary-link"
+                                className="admin-action-link"
                                 href="/admin"
                                 onNavigate={onNavigate}
                                 preserveScroll={true}>


### PR DESCRIPTION
## Summary
- replace the plain browser-default admin workspace links with button-style CTA links
- apply the same styling to overview cards, the session card, and the section-detail return action
- keep the change scoped to the admin workspace so existing project link styles are unaffected

## Issue
- Follow-up for #64

## Verification
- `npm test`
- `npm run build`
- `npm run lint`

## Context
- PR #114 merged the admin workspace structure into `dev`
- this PR is a focused styling cleanup for the workspace actions