### PR TITLE
feat: add resume import file staging (#91)

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportControllerTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Controllers;
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class ResumeImportControllerTests
+{
+    [Test]
+    public async Task ParseAsync_ReturnsBadRequestWhenFileIsMissing()
+    {
+        var controller = new ResumeImportController(new StubResumeImportService());
+
+        var result = await controller.ParseAsync(null, CancellationToken.None);
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        var error = (result.Result as BadRequestObjectResult)?.Value as ApiErrorResponse;
+        Assert.That(error?.Message, Is.EqualTo("A resume file is required."));
+    }
+
+    [Test]
+    public async Task ParseAsync_ReturnsBadRequestWhenUploadValidationFails()
+    {
+        var controller = new ResumeImportController(new StubResumeImportService
+        {
+            ExceptionToThrow = new ResumeImportValidationException("Only PDF and DOCX resume files are supported.")
+        });
+
+        var result = await controller.ParseAsync(CreateFormFile("resume.txt"), CancellationToken.None);
+
+        Assert.That(result.Result, Is.InstanceOf<BadRequestObjectResult>());
+        var error = (result.Result as BadRequestObjectResult)?.Value as ApiErrorResponse;
+        Assert.That(error?.Message, Is.EqualTo("Only PDF and DOCX resume files are supported."));
+    }
+
+    [Test]
+    public async Task ParseAsync_ReturnsParsedPayloadWhenUploadSucceeds()
+    {
+        var controller = new ResumeImportController(new StubResumeImportService
+        {
+            Result = new ResumeImportParseResult
+            {
+                SourceFileName = "resume.pdf",
+                ParserName = "StubParser",
+                GlobalSkills = ["C#"]
+            }
+        });
+
+        var result = await controller.ParseAsync(CreateFormFile("resume.pdf"), CancellationToken.None);
+
+        Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+        var response = (result.Result as OkObjectResult)?.Value;
+        Assert.That(response, Is.Not.Null);
+    }
+
+    private static FormFile CreateFormFile(string fileName)
+    {
+        return new FormFile(new MemoryStream([1, 2, 3]), 0, 3, "file", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/octet-stream"
+        };
+    }
+
+    private sealed class StubResumeImportService : IResumeImportService
+    {
+        public ResumeImportValidationException? ExceptionToThrow { get; set; }
+
+        public ResumeImportParseResult Result { get; set; } = new();
+
+        public Task<ResumeImportParseResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default)
+        {
+            if (ExceptionToThrow is not null)
+            {
+                throw ExceptionToThrow;
+            }
+
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportServiceTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportServiceTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Services.Implementations;
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class ResumeImportServiceTests
+{
+    private string tempRootPath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempRootPath = Path.Combine(Path.GetTempPath(), "ProjectPortfolio2026.Tests", Guid.NewGuid().ToString("N"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempRootPath))
+        {
+            Directory.Delete(tempRootPath, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ParseAsync_DeletesTemporaryUploadAfterSuccessfulParse()
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var parser = new TrackingResumeParserService();
+        var service = new ResumeImportService(store, parser);
+        var file = CreateFormFile("resume.pdf", "application/pdf", [9, 8, 7]);
+
+        var result = await service.ParseAsync(file);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SourceFileName, Is.EqualTo("resume.pdf"));
+            Assert.That(parser.CapturedFileName, Is.EqualTo("resume.pdf"));
+            Assert.That(parser.CapturedBytes, Is.EqualTo(new byte[] { 9, 8, 7 }));
+            Assert.That(Directory.Exists(tempRootPath), Is.True);
+            Assert.That(Directory.EnumerateFiles(tempRootPath), Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ParseAsync_DeletesTemporaryUploadWhenParserFails()
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var parser = new ThrowingResumeParserService();
+        var service = new ResumeImportService(store, parser);
+        var file = CreateFormFile("resume.pdf", "application/pdf", [1, 2, 3]);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ParseAsync(file));
+        Assert.That(Directory.Exists(tempRootPath), Is.True);
+        Assert.That(Directory.EnumerateFiles(tempRootPath), Is.Empty);
+    }
+
+    private static FormFile CreateFormFile(string fileName, string contentType, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+        var formFile = new FormFile(stream, 0, content.Length, "file", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType
+        };
+
+        return formFile;
+    }
+
+    private sealed class TrackingResumeParserService : IResumeParserService
+    {
+        public byte[] CapturedBytes { get; private set; } = [];
+
+        public string? CapturedFileName { get; private set; }
+
+        public async Task<ResumeImportParseResult> ParseAsync(
+            Stream content,
+            string fileName,
+            CancellationToken cancellationToken = default)
+        {
+            using var memoryStream = new MemoryStream();
+            await content.CopyToAsync(memoryStream, cancellationToken);
+            CapturedBytes = memoryStream.ToArray();
+            CapturedFileName = fileName;
+
+            return new ResumeImportParseResult
+            {
+                ParserName = "TrackingResumeParserService"
+            };
+        }
+    }
+
+    private sealed class ThrowingResumeParserService : IResumeParserService
+    {
+        public Task<ResumeImportParseResult> ParseAsync(
+            Stream content,
+            string fileName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Parser failed.");
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/TemporaryResumeFileStoreTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/TemporaryResumeFileStoreTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Services.Implementations;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class TemporaryResumeFileStoreTests
+{
+    private string tempRootPath = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempRootPath = Path.Combine(Path.GetTempPath(), "ProjectPortfolio2026.Tests", Guid.NewGuid().ToString("N"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempRootPath))
+        {
+            Directory.Delete(tempRootPath, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task StageAsync_CopiesSupportedPdfAndDeletesItOnDispose()
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var file = CreateFormFile("resume.pdf", "application/pdf", [1, 2, 3, 4]);
+
+        var stagedFile = await store.StageAsync(file);
+
+        Assert.That(File.Exists(stagedFile.StoredFilePath), Is.True);
+        Assert.That(await File.ReadAllBytesAsync(stagedFile.StoredFilePath), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+
+        await stagedFile.DisposeAsync();
+
+        Assert.That(File.Exists(stagedFile.StoredFilePath), Is.False);
+    }
+
+    [Test]
+    public void StageAsync_RejectsUnsupportedFileExtension()
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var file = CreateFormFile("resume.txt", "text/plain", [1, 2, 3]);
+
+        var exception = Assert.ThrowsAsync<ResumeImportValidationException>(async () => await store.StageAsync(file));
+
+        Assert.That(exception?.Message, Is.EqualTo("Only PDF and DOCX resume files are supported."));
+    }
+
+    [Test]
+    public void StageAsync_RejectsEmptyFiles()
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var file = CreateFormFile("resume.pdf", "application/pdf", []);
+
+        var exception = Assert.ThrowsAsync<ResumeImportValidationException>(async () => await store.StageAsync(file));
+
+        Assert.That(exception?.Message, Is.EqualTo("The uploaded resume file is empty."));
+    }
+
+    private static FormFile CreateFormFile(string fileName, string contentType, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+        var formFile = new FormFile(stream, 0, content.Length, "file", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType
+        };
+
+        return formFile;
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Admin/ResumeImport/ResumeImportParseResponse.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Admin/ResumeImport/ResumeImportParseResponse.cs
@@ -1,0 +1,100 @@
+using ProjectPortfolio2026.Server.Contracts;
+
+namespace ProjectPortfolio2026.Server.Contracts.Admin.ResumeImport;
+
+public sealed class ResumeImportParseResponse : ApiResponseDto
+{
+    public ResumeImportPersonResponse? Person { get; set; }
+
+    public List<ResumeImportWorkHistoryEntryResponse> WorkHistory { get; set; } = [];
+
+    public List<string> GlobalSkills { get; set; } = [];
+
+    public string? ProfessionalSummary { get; set; }
+
+    public string? RawText { get; set; }
+
+    public string? SourceFileName { get; set; }
+
+    public string? ParserName { get; set; }
+}
+
+public sealed class ResumeImportPersonResponse
+{
+    public string? FullName { get; set; }
+
+    public string? FirstName { get; set; }
+
+    public string? MiddleName { get; set; }
+
+    public string? LastName { get; set; }
+
+    public string? Headline { get; set; }
+
+    public string? EmailAddress { get; set; }
+
+    public List<string> PhoneNumbers { get; set; } = [];
+
+    public ResumeImportLocationResponse? Location { get; set; }
+
+    public List<string> SocialProfiles { get; set; } = [];
+}
+
+public sealed class ResumeImportLocationResponse
+{
+    public string? StreetAddress1 { get; set; }
+
+    public string? StreetAddress2 { get; set; }
+
+    public string? City { get; set; }
+
+    public string? Region { get; set; }
+
+    public string? PostalCode { get; set; }
+
+    public string? Country { get; set; }
+
+    public string? DisplayText { get; set; }
+}
+
+public sealed class ResumeImportWorkHistoryEntryResponse
+{
+    public string? EmployerName { get; set; }
+
+    public ResumeImportLocationResponse? EmployerLocation { get; set; }
+
+    public string? JobTitle { get; set; }
+
+    public string? EmploymentType { get; set; }
+
+    public string? SupervisorName { get; set; }
+
+    public ResumeImportDateRangeResponse EmploymentDates { get; set; } = new();
+
+    public List<string> DescriptionLines { get; set; } = [];
+
+    public string? DescriptionMarkdown { get; set; }
+
+    public List<string> Skills { get; set; } = [];
+
+    public List<string> Technologies { get; set; } = [];
+
+    public List<string> Tags { get; set; } = [];
+
+    public string? RawRoleText { get; set; }
+
+    public Dictionary<string, string?> RawFields { get; set; } = new(StringComparer.Ordinal);
+}
+
+public sealed class ResumeImportDateRangeResponse
+{
+    public string? StartDateText { get; set; }
+
+    public string? EndDateText { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    public bool IsCurrentRole { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/ResumeImportController.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/ResumeImportController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Contracts.Admin.ResumeImport;
+using ProjectPortfolio2026.Server.Domain.Identity;
+using ProjectPortfolio2026.Server.Mappers;
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Controllers;
+
+[ApiController]
+[Route("api/admin/resume-import")]
+[Authorize(Roles = RoleNames.Admin)]
+public sealed class ResumeImportController(IResumeImportService resumeImportService) : ControllerBase
+{
+    [HttpPost("parse")]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType<ResumeImportParseResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiErrorResponse>(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ResumeImportParseResponse>> ParseAsync(
+        IFormFile? file,
+        CancellationToken cancellationToken)
+    {
+        if (file is null)
+        {
+            return BadRequest(new ApiErrorResponse
+            {
+                StatusCode = StatusCodes.Status400BadRequest,
+                ErrorCode = "resume_file_required",
+                Message = "A resume file is required."
+            });
+        }
+
+        try
+        {
+            var result = await resumeImportService.ParseAsync(file, cancellationToken);
+            return Ok(ResumeImportContractMapper.Map(result));
+        }
+        catch (ResumeImportValidationException exception)
+        {
+            return BadRequest(new ApiErrorResponse
+            {
+                StatusCode = StatusCodes.Status400BadRequest,
+                ErrorCode = "resume_file_invalid",
+                Message = exception.Message
+            });
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/ResumeImportContractMapper.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/ResumeImportContractMapper.cs
@@ -1,0 +1,88 @@
+using ProjectPortfolio2026.Server.Contracts.Admin.ResumeImport;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Mappers;
+
+public static class ResumeImportContractMapper
+{
+    public static ResumeImportParseResponse Map(ResumeImportParseResult result)
+    {
+        return new ResumeImportParseResponse
+        {
+            Person = Map(result.Person),
+            WorkHistory = result.WorkHistory.Select(Map).ToList(),
+            GlobalSkills = [.. result.GlobalSkills],
+            ProfessionalSummary = result.ProfessionalSummary,
+            RawText = result.RawText,
+            SourceFileName = result.SourceFileName,
+            ParserName = result.ParserName
+        };
+    }
+
+    private static ResumeImportPersonResponse? Map(ParsedPerson? person)
+    {
+        if (person is null)
+        {
+            return null;
+        }
+
+        return new ResumeImportPersonResponse
+        {
+            FullName = person.FullName,
+            FirstName = person.FirstName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            Headline = person.Headline,
+            EmailAddress = person.EmailAddress,
+            PhoneNumbers = [.. person.PhoneNumbers],
+            Location = Map(person.Location),
+            SocialProfiles = [.. person.SocialProfiles]
+        };
+    }
+
+    private static ResumeImportLocationResponse? Map(ParsedLocation? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        return new ResumeImportLocationResponse
+        {
+            StreetAddress1 = location.StreetAddress1,
+            StreetAddress2 = location.StreetAddress2,
+            City = location.City,
+            Region = location.Region,
+            PostalCode = location.PostalCode,
+            Country = location.Country,
+            DisplayText = location.DisplayText
+        };
+    }
+
+    private static ResumeImportWorkHistoryEntryResponse Map(ParsedWorkHistoryEntry entry)
+    {
+        return new ResumeImportWorkHistoryEntryResponse
+        {
+            EmployerName = entry.EmployerName,
+            EmployerLocation = Map(entry.EmployerLocation),
+            JobTitle = entry.JobTitle,
+            EmploymentType = entry.EmploymentType,
+            SupervisorName = entry.SupervisorName,
+            EmploymentDates = new ResumeImportDateRangeResponse
+            {
+                StartDateText = entry.EmploymentDates.StartDateText,
+                EndDateText = entry.EmploymentDates.EndDateText,
+                StartDate = entry.EmploymentDates.StartDate,
+                EndDate = entry.EmploymentDates.EndDate,
+                IsCurrentRole = entry.EmploymentDates.IsCurrentRole
+            },
+            DescriptionLines = [.. entry.DescriptionLines],
+            DescriptionMarkdown = entry.DescriptionMarkdown,
+            Skills = [.. entry.Skills],
+            Technologies = [.. entry.Technologies],
+            Tags = [.. entry.Tags],
+            RawRoleText = entry.RawRoleText,
+            RawFields = new Dictionary<string, string?>(entry.RawFields, StringComparer.Ordinal)
+        };
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
@@ -88,6 +88,9 @@ builder.Services.AddScoped<IProjectRepository, ProjectRepository>();
 builder.Services.AddScoped<IEmployerRepository, EmployerRepository>();
 builder.Services.AddScoped<ICurrentUserAccessor, CurrentUserAccessor>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddSingleton<IResumeImportFileStore>(_ => new TemporaryResumeFileStore());
+builder.Services.AddScoped<IResumeParserService, DeferredResumeParserService>();
+builder.Services.AddScoped<IResumeImportService, ResumeImportService>();
 builder.Services.AddScoped<RequestTrackingFilter>();
 
 var app = builder.Build();

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/DeferredResumeParserService.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/DeferredResumeParserService.cs
@@ -1,0 +1,19 @@
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Implementations;
+
+public sealed class DeferredResumeParserService : IResumeParserService
+{
+    public Task<ResumeImportParseResult> ParseAsync(
+        Stream content,
+        string fileName,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new ResumeImportParseResult
+        {
+            SourceFileName = fileName,
+            ParserName = nameof(DeferredResumeParserService)
+        });
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportService.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportService.cs
@@ -1,0 +1,20 @@
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Implementations;
+
+public sealed class ResumeImportService(
+    IResumeImportFileStore resumeImportFileStore,
+    IResumeParserService resumeParserService) : IResumeImportService
+{
+    public async Task<ResumeImportParseResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default)
+    {
+        await using var stagedFile = await resumeImportFileStore.StageAsync(file, cancellationToken);
+        await using var content = File.OpenRead(stagedFile.StoredFilePath);
+
+        var result = await resumeParserService.ParseAsync(content, stagedFile.OriginalFileName, cancellationToken);
+        result.SourceFileName ??= stagedFile.OriginalFileName;
+
+        return result;
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/TemporaryResumeFileStore.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/TemporaryResumeFileStore.cs
@@ -1,0 +1,84 @@
+using ProjectPortfolio2026.Server.Services.Interfaces;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Implementations;
+
+public sealed class TemporaryResumeFileStore : IResumeImportFileStore
+{
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".pdf",
+        ".docx"
+    };
+
+    private readonly string stagingRootPath;
+
+    public TemporaryResumeFileStore()
+        : this(Path.Combine(Path.GetTempPath(), "ProjectPortfolio2026", "resume-imports"))
+    {
+    }
+
+    public TemporaryResumeFileStore(string stagingRootPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagingRootPath);
+        this.stagingRootPath = stagingRootPath;
+    }
+
+    public async Task<StagedResumeFile> StageAsync(IFormFile file, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        var originalFileName = Path.GetFileName(file.FileName);
+        var extension = Path.GetExtension(originalFileName);
+
+        if (string.IsNullOrWhiteSpace(originalFileName))
+        {
+            throw new ResumeImportValidationException("A resume file is required.");
+        }
+
+        if (file.Length <= 0)
+        {
+            throw new ResumeImportValidationException("The uploaded resume file is empty.");
+        }
+
+        if (!SupportedExtensions.Contains(extension))
+        {
+            throw new ResumeImportValidationException("Only PDF and DOCX resume files are supported.");
+        }
+
+        Directory.CreateDirectory(stagingRootPath);
+
+        var storedFilePath = Path.Combine(
+            stagingRootPath,
+            $"{Guid.NewGuid():N}{extension.ToLowerInvariant()}");
+
+        try
+        {
+            await using var targetStream = new FileStream(
+                storedFilePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                useAsync: true);
+
+            await using var sourceStream = file.OpenReadStream();
+            await sourceStream.CopyToAsync(targetStream, cancellationToken);
+        }
+        catch
+        {
+            if (File.Exists(storedFilePath))
+            {
+                File.Delete(storedFilePath);
+            }
+
+            throw;
+        }
+
+        return new StagedResumeFile(
+            storedFilePath,
+            originalFileName,
+            file.ContentType ?? string.Empty,
+            file.Length);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeImportFileStore.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeImportFileStore.cs
@@ -1,0 +1,8 @@
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Interfaces;
+
+public interface IResumeImportFileStore
+{
+    Task<StagedResumeFile> StageAsync(IFormFile file, CancellationToken cancellationToken = default);
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeImportService.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeImportService.cs
@@ -1,0 +1,8 @@
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Interfaces;
+
+public interface IResumeImportService
+{
+    Task<ResumeImportParseResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default);
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeParserService.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeParserService.cs
@@ -1,0 +1,11 @@
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Interfaces;
+
+public interface IResumeParserService
+{
+    Task<ResumeImportParseResult> ParseAsync(
+        Stream content,
+        string fileName,
+        CancellationToken cancellationToken = default);
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportParseResult.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportParseResult.cs
@@ -1,0 +1,98 @@
+namespace ProjectPortfolio2026.Server.Services.ServiceModels;
+
+public sealed class ResumeImportParseResult
+{
+    public ParsedPerson? Person { get; set; }
+
+    public List<ParsedWorkHistoryEntry> WorkHistory { get; set; } = [];
+
+    public List<string> GlobalSkills { get; set; } = [];
+
+    public string? ProfessionalSummary { get; set; }
+
+    public string? RawText { get; set; }
+
+    public string? SourceFileName { get; set; }
+
+    public string? ParserName { get; set; }
+}
+
+public sealed class ParsedPerson
+{
+    public string? FullName { get; set; }
+
+    public string? FirstName { get; set; }
+
+    public string? MiddleName { get; set; }
+
+    public string? LastName { get; set; }
+
+    public string? Headline { get; set; }
+
+    public string? EmailAddress { get; set; }
+
+    public List<string> PhoneNumbers { get; set; } = [];
+
+    public ParsedLocation? Location { get; set; }
+
+    public List<string> SocialProfiles { get; set; } = [];
+}
+
+public sealed class ParsedLocation
+{
+    public string? StreetAddress1 { get; set; }
+
+    public string? StreetAddress2 { get; set; }
+
+    public string? City { get; set; }
+
+    public string? Region { get; set; }
+
+    public string? PostalCode { get; set; }
+
+    public string? Country { get; set; }
+
+    public string? DisplayText { get; set; }
+}
+
+public sealed class ParsedWorkHistoryEntry
+{
+    public string? EmployerName { get; set; }
+
+    public ParsedLocation? EmployerLocation { get; set; }
+
+    public string? JobTitle { get; set; }
+
+    public string? EmploymentType { get; set; }
+
+    public string? SupervisorName { get; set; }
+
+    public ParsedDateRange EmploymentDates { get; set; } = new();
+
+    public List<string> DescriptionLines { get; set; } = [];
+
+    public string? DescriptionMarkdown { get; set; }
+
+    public List<string> Skills { get; set; } = [];
+
+    public List<string> Technologies { get; set; } = [];
+
+    public List<string> Tags { get; set; } = [];
+
+    public string? RawRoleText { get; set; }
+
+    public Dictionary<string, string?> RawFields { get; set; } = new(StringComparer.Ordinal);
+}
+
+public sealed class ParsedDateRange
+{
+    public string? StartDateText { get; set; }
+
+    public string? EndDateText { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    public bool IsCurrentRole { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportValidationException.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportValidationException.cs
@@ -1,0 +1,3 @@
+namespace ProjectPortfolio2026.Server.Services.ServiceModels;
+
+public sealed class ResumeImportValidationException(string message) : Exception(message);

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/StagedResumeFile.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/StagedResumeFile.cs
@@ -1,0 +1,26 @@
+namespace ProjectPortfolio2026.Server.Services.ServiceModels;
+
+public sealed class StagedResumeFile(
+    string storedFilePath,
+    string originalFileName,
+    string contentType,
+    long fileLength) : IAsyncDisposable
+{
+    public string StoredFilePath { get; } = storedFilePath;
+
+    public string OriginalFileName { get; } = originalFileName;
+
+    public string ContentType { get; } = contentType;
+
+    public long FileLength { get; } = fileLength;
+
+    public ValueTask DisposeAsync()
+    {
+        if (File.Exists(StoredFilePath))
+        {
+            File.Delete(StoredFilePath);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #91

## Summary
- add an admin resume-import parse endpoint that accepts multipart uploads
- stage supported PDF and DOCX files into transient temp storage before parsing and always clean them up afterward
- introduce typed resume import DTOs plus tests covering upload validation and cleanup on both success and parser failure

## Validation
- `dotnet test .\ProjectPortfolio2026.Server.Tests\ProjectPortfolio2026.Server.Tests.csproj`