### PR TITLE
#67 Add admin resume configuration management

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AdminResumeConfigurationControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AdminResumeConfigurationControllerTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Contracts.Admin;
+using ProjectPortfolio2026.Server.Contracts.Resume;
+using ProjectPortfolio2026.Server.Controllers;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Repositories;
+using System.Security.Claims;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class AdminResumeConfigurationControllerTests
+{
+    [Test]
+    public async Task GetAsync_ReturnsDefaultConfigurationWhenNothingIsSavedYet()
+    {
+        var controller = CreateController(new StubResumeConfigurationRepository());
+
+        var actionResult = await controller.GetAsync(CancellationToken.None);
+        var okResult = actionResult.Result as OkObjectResult;
+        var response = okResult?.Value as ResumeConfigurationResponse;
+
+        Assert.That(response, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(response!.SourceType, Is.EqualTo(ResumeSourceTypes.None));
+            Assert.That(response.IsConfigured, Is.False);
+            Assert.That(response.SourceUrl, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task UpdateAsync_ReturnsValidationProblemWhenEnabledSourceIsIncomplete()
+    {
+        var controller = CreateController(new StubResumeConfigurationRepository());
+
+        var actionResult = await controller.UpdateAsync(
+            new ResumeConfigurationUpdateRequest
+            {
+                SourceType = ResumeSourceTypes.HostedFile,
+                SourceUrl = "https://cdn.example.dev/resume.pdf",
+                DisplayLabel = ""
+            },
+            CancellationToken.None);
+
+        Assert.That(actionResult.Result, Is.InstanceOf<BadRequestObjectResult>());
+        var validationProblem = (actionResult.Result as BadRequestObjectResult)?.Value as ValidationProblemDetails;
+        Assert.That(validationProblem?.Errors, Contains.Key("displayLabel"));
+    }
+
+    [Test]
+    public async Task UpdateAsync_PersistsTrimmedConfiguration()
+    {
+        var repository = new StubResumeConfigurationRepository();
+        var controller = CreateController(repository);
+        controller.ControllerContext.HttpContext.Items[RequestIdContext.ItemKey] = "admin-config-request";
+
+        var actionResult = await controller.UpdateAsync(
+            new ResumeConfigurationUpdateRequest
+            {
+                SourceType = " Hosted-File ",
+                SourceUrl = " https://cdn.example.dev/resume.pdf ",
+                DisplayLabel = " Download Resume ",
+                Summary = " ATS-friendly export. "
+            },
+            CancellationToken.None);
+
+        var okResult = actionResult.Result as OkObjectResult;
+        var response = okResult?.Value as ResumeConfigurationResponse;
+
+        Assert.That(response, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(response!.RequestId, Is.EqualTo("admin-config-request"));
+            Assert.That(response.SourceType, Is.EqualTo(ResumeSourceTypes.HostedFile));
+            Assert.That(response.SourceUrl, Is.EqualTo("https://cdn.example.dev/resume.pdf"));
+            Assert.That(response.DisplayLabel, Is.EqualTo("Download Resume"));
+            Assert.That(response.Summary, Is.EqualTo("ATS-friendly export."));
+            Assert.That(response.IsConfigured, Is.True);
+            Assert.That(repository.Configuration?.DisplayLabel, Is.EqualTo("Download Resume"));
+        });
+    }
+
+    private static AdminResumeConfigurationController CreateController(IResumeConfigurationRepository repository)
+    {
+        return new AdminResumeConfigurationController(repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "admin")], "test"))
+                }
+            }
+        };
+    }
+
+    private sealed class StubResumeConfigurationRepository : IResumeConfigurationRepository
+    {
+        public ResumeConfiguration? Configuration { get; set; }
+
+        public Task<ResumeConfiguration?> GetAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Configuration);
+        }
+
+        public Task<ResumeConfiguration> SaveAsync(ResumeConfiguration configuration, CancellationToken cancellationToken = default)
+        {
+            Configuration = configuration;
+            configuration.Id = configuration.Id == 0 ? 1 : configuration.Id;
+            return Task.FromResult(configuration);
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AdminResumeConfigurationControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/AdminResumeConfigurationControllerTests.cs
@@ -52,6 +52,25 @@ public sealed class AdminResumeConfigurationControllerTests
     }
 
     [Test]
+    public async Task UpdateAsync_ReturnsValidationProblemWhenSourceTypeIsUnsupported()
+    {
+        var controller = CreateController(new StubResumeConfigurationRepository());
+
+        var actionResult = await controller.UpdateAsync(
+            new ResumeConfigurationUpdateRequest
+            {
+                SourceType = "sharepoint-link",
+                SourceUrl = "https://cdn.example.dev/resume.pdf",
+                DisplayLabel = "Download Resume"
+            },
+            CancellationToken.None);
+
+        Assert.That(actionResult.Result, Is.InstanceOf<BadRequestObjectResult>());
+        var validationProblem = (actionResult.Result as BadRequestObjectResult)?.Value as ValidationProblemDetails;
+        Assert.That(validationProblem?.Errors, Contains.Key("sourceType"));
+    }
+
+    [Test]
     public async Task UpdateAsync_PersistsTrimmedConfiguration()
     {
         var repository = new StubResumeConfigurationRepository();

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeConfigurationControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeConfigurationControllerTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Contracts.Resume;
+using ProjectPortfolio2026.Server.Controllers;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Repositories;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class ResumeConfigurationControllerTests
+{
+    [Test]
+    public async Task GetAsync_ReturnsConfiguredPublicResumeSource()
+    {
+        var controller = CreateController(new StubResumeConfigurationRepository
+        {
+            Configuration = new ResumeConfiguration
+            {
+                Id = 3,
+                SourceType = ResumeSourceTypes.HostedFile,
+                SourceUrl = "https://cdn.example.dev/resume.pdf",
+                DisplayLabel = "Download Resume",
+                Summary = "ATS-friendly PDF."
+            }
+        });
+        controller.ControllerContext.HttpContext.Items[RequestIdContext.ItemKey] = "resume-config-request";
+
+        var actionResult = await controller.GetAsync(CancellationToken.None);
+        var okResult = actionResult.Result as OkObjectResult;
+        var response = okResult?.Value as ResumeConfigurationResponse;
+
+        Assert.That(response, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(response!.RequestId, Is.EqualTo("resume-config-request"));
+            Assert.That(response.SourceType, Is.EqualTo(ResumeSourceTypes.HostedFile));
+            Assert.That(response.DisplayLabel, Is.EqualTo("Download Resume"));
+            Assert.That(response.IsConfigured, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task GetAsync_ReturnsNotFoundWhenConfigurationIsIncomplete()
+    {
+        var controller = CreateController(new StubResumeConfigurationRepository
+        {
+            Configuration = new ResumeConfiguration
+            {
+                SourceType = ResumeSourceTypes.HostedFile,
+                SourceUrl = "https://cdn.example.dev/resume.pdf",
+                DisplayLabel = null
+            }
+        });
+
+        var actionResult = await controller.GetAsync(CancellationToken.None);
+        var notFoundResult = actionResult.Result as NotFoundObjectResult;
+        var response = notFoundResult?.Value as ApiErrorResponse;
+
+        Assert.That(notFoundResult, Is.Not.Null);
+        Assert.That(response?.Message, Is.EqualTo("The requested resume configuration could not be found."));
+    }
+
+    private static ResumeConfigurationController CreateController(IResumeConfigurationRepository repository)
+    {
+        return new ResumeConfigurationController(repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    private sealed class StubResumeConfigurationRepository : IResumeConfigurationRepository
+    {
+        public ResumeConfiguration? Configuration { get; set; }
+
+        public Task<ResumeConfiguration?> GetAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Configuration);
+        }
+
+        public Task<ResumeConfiguration> SaveAsync(ResumeConfiguration configuration, CancellationToken cancellationToken = default)
+        {
+            Configuration = configuration;
+            return Task.FromResult(configuration);
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeConfigurationRepositoryTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeConfigurationRepositoryTests.cs
@@ -74,6 +74,30 @@ public sealed class ResumeConfigurationRepositoryTests
         });
     }
 
+    [Test]
+    public async Task SaveAsync_CreatesFirstConfigurationWhenDatabaseIsEmpty()
+    {
+        await using var dbContext = CreateDbContext();
+        var repository = new ResumeConfigurationRepository(dbContext);
+
+        var savedConfiguration = await repository.SaveAsync(new ResumeConfiguration
+        {
+            SourceType = ResumeSourceTypes.HostedFile,
+            SourceUrl = "https://cdn.example.dev/resume-v1.pdf",
+            DisplayLabel = "Download Resume",
+            Summary = "Initial summary"
+        });
+
+        var persistedConfigurations = await dbContext.ResumeConfigurations.ToListAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(savedConfiguration.Id, Is.GreaterThan(0));
+            Assert.That(persistedConfigurations, Has.Count.EqualTo(1));
+            Assert.That(persistedConfigurations[0].DisplayLabel, Is.EqualTo("Download Resume"));
+        });
+    }
+
     private static PortfolioDbContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<PortfolioDbContext>()

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeConfigurationRepositoryTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeConfigurationRepositoryTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Data;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Repositories;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class ResumeConfigurationRepositoryTests
+{
+    [Test]
+    public async Task GetAsync_ReturnsNewestConfiguration()
+    {
+        await using var dbContext = CreateDbContext();
+        dbContext.ResumeConfigurations.AddRange(
+            new ResumeConfiguration
+            {
+                SourceType = ResumeSourceTypes.HostedFile,
+                SourceUrl = "https://cdn.example.dev/resume-v1.pdf",
+                DisplayLabel = "Download Resume"
+            },
+            new ResumeConfiguration
+            {
+                SourceType = ResumeSourceTypes.Embed,
+                SourceUrl = "https://drive.example.dev/embed/resume",
+                DisplayLabel = "Open Embedded Resume"
+            });
+        await dbContext.SaveChangesAsync();
+
+        var repository = new ResumeConfigurationRepository(dbContext);
+        var configuration = await repository.GetAsync();
+
+        Assert.That(configuration, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration!.SourceType, Is.EqualTo(ResumeSourceTypes.Embed));
+            Assert.That(configuration.SourceUrl, Is.EqualTo("https://drive.example.dev/embed/resume"));
+            Assert.That(configuration.DisplayLabel, Is.EqualTo("Open Embedded Resume"));
+        });
+    }
+
+    [Test]
+    public async Task SaveAsync_UpdatesExistingSingletonRecord()
+    {
+        await using var dbContext = CreateDbContext();
+        dbContext.ResumeConfigurations.Add(new ResumeConfiguration
+        {
+            SourceType = ResumeSourceTypes.HostedFile,
+            SourceUrl = "https://cdn.example.dev/resume-v1.pdf",
+            DisplayLabel = "Download Resume",
+            Summary = "Original summary"
+        });
+        await dbContext.SaveChangesAsync();
+
+        var repository = new ResumeConfigurationRepository(dbContext);
+        var savedConfiguration = await repository.SaveAsync(new ResumeConfiguration
+        {
+            SourceType = ResumeSourceTypes.Embed,
+            SourceUrl = "https://drive.example.dev/embed/resume",
+            DisplayLabel = "Open Embedded Resume",
+            Summary = "Updated summary"
+        });
+
+        var persistedConfigurations = await dbContext.ResumeConfigurations.OrderBy(configuration => configuration.Id).ToListAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(savedConfiguration.Id, Is.GreaterThan(0));
+            Assert.That(persistedConfigurations, Has.Count.EqualTo(1));
+            Assert.That(persistedConfigurations[0].SourceType, Is.EqualTo(ResumeSourceTypes.Embed));
+            Assert.That(persistedConfigurations[0].DisplayLabel, Is.EqualTo("Open Embedded Resume"));
+            Assert.That(persistedConfigurations[0].Summary, Is.EqualTo("Updated summary"));
+        });
+    }
+
+    private static PortfolioDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<PortfolioDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+
+        return new PortfolioDbContext(options);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Admin/ResumeConfigurationUpdateRequest.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Admin/ResumeConfigurationUpdateRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectPortfolio2026.Server.Contracts.Admin;
+
+public sealed class ResumeConfigurationUpdateRequest
+{
+    [Required]
+    [MaxLength(30)]
+    public string SourceType { get; set; } = string.Empty;
+
+    [MaxLength(2048)]
+    public string? SourceUrl { get; set; }
+
+    [MaxLength(120)]
+    public string? DisplayLabel { get; set; }
+
+    [MaxLength(280)]
+    public string? Summary { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Resume/ResumeConfigurationResponse.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Resume/ResumeConfigurationResponse.cs
@@ -1,0 +1,18 @@
+using ProjectPortfolio2026.Server.Contracts;
+
+namespace ProjectPortfolio2026.Server.Contracts.Resume;
+
+public sealed class ResumeConfigurationResponse : ApiResponseDto
+{
+    public int Id { get; set; }
+
+    public string SourceType { get; set; } = string.Empty;
+
+    public string? SourceUrl { get; set; }
+
+    public string? DisplayLabel { get; set; }
+
+    public string? Summary { get; set; }
+
+    public bool IsConfigured { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/AdminResumeConfigurationController.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/AdminResumeConfigurationController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ProjectPortfolio2026.Server.Contracts.Admin;
+using ProjectPortfolio2026.Server.Contracts.Resume;
+using ProjectPortfolio2026.Server.Domain.Identity;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Mappers;
+using ProjectPortfolio2026.Server.Repositories;
+
+namespace ProjectPortfolio2026.Server.Controllers;
+
+[ApiController]
+[Route("api/admin/resume-configuration")]
+[Authorize(Roles = RoleNames.Admin)]
+public sealed class AdminResumeConfigurationController(IResumeConfigurationRepository resumeConfigurationRepository) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType<ResumeConfigurationResponse>(StatusCodes.Status200OK)]
+    public async Task<ActionResult<ResumeConfigurationResponse>> GetAsync(CancellationToken cancellationToken)
+    {
+        var requestId = HttpContext.Items[RequestIdContext.ItemKey] as string;
+        var configuration = await resumeConfigurationRepository.GetAsync(cancellationToken)
+            ?? new ResumeConfiguration();
+
+        return Ok(configuration.ToResponse(requestId));
+    }
+
+    [HttpPut]
+    [ValidateAntiForgeryToken]
+    [ProducesResponseType<ResumeConfigurationResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ResumeConfigurationResponse>> UpdateAsync(
+        [FromBody] ResumeConfigurationUpdateRequest request,
+        CancellationToken cancellationToken)
+    {
+        var validationErrors = ResumeConfigurationRules.Validate(request.SourceType, request.SourceUrl, request.DisplayLabel);
+        if (validationErrors.Count > 0)
+        {
+            return BadRequest(new ValidationProblemDetails(validationErrors.ToDictionary(pair => pair.Key, pair => pair.Value)));
+        }
+
+        var savedConfiguration = await resumeConfigurationRepository.SaveAsync(
+            new ResumeConfiguration
+            {
+                SourceType = ResumeSourceTypes.Normalize(request.SourceType),
+                SourceUrl = ResumeConfigurationRules.NormalizeText(request.SourceUrl),
+                DisplayLabel = ResumeConfigurationRules.NormalizeText(request.DisplayLabel),
+                Summary = ResumeConfigurationRules.NormalizeText(request.Summary)
+            },
+            cancellationToken);
+
+        var requestId = HttpContext.Items[RequestIdContext.ItemKey] as string;
+        return Ok(savedConfiguration.ToResponse(requestId));
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/ResumeConfigurationController.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Controllers/ResumeConfigurationController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Contracts.Resume;
+using ProjectPortfolio2026.Server.Infrastructure.RequestTracking;
+using ProjectPortfolio2026.Server.Mappers;
+using ProjectPortfolio2026.Server.Repositories;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Controllers;
+
+[ApiController]
+[Route("api/resume-configuration")]
+public sealed class ResumeConfigurationController(IResumeConfigurationRepository resumeConfigurationRepository) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType<ResumeConfigurationResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiErrorResponse>(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ResumeConfigurationResponse>> GetAsync(CancellationToken cancellationToken)
+    {
+        var configuration = await resumeConfigurationRepository.GetAsync(cancellationToken);
+        if (!ResumeConfigurationRules.HasCompletePublicConfiguration(configuration))
+        {
+            return NotFound(new ApiErrorResponse { Message = "The requested resume configuration could not be found." });
+        }
+
+        var requestId = HttpContext.Items[RequestIdContext.ItemKey] as string;
+        return Ok(configuration!.ToResponse(requestId));
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/ResumeConfigurationConfiguration.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/Configurations/ResumeConfigurationConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Data.Configurations;
+
+public sealed class ResumeConfigurationConfiguration : IEntityTypeConfiguration<ResumeConfiguration>
+{
+    public void Configure(EntityTypeBuilder<ResumeConfiguration> builder)
+    {
+        builder.ToTable("ResumeConfigurations");
+
+        builder.Property(configuration => configuration.SourceType)
+            .IsRequired()
+            .HasMaxLength(30)
+            .HasDefaultValue(ResumeSourceTypes.None);
+
+        builder.Property(configuration => configuration.SourceUrl)
+            .HasMaxLength(2048);
+
+        builder.Property(configuration => configuration.DisplayLabel)
+            .HasMaxLength(120);
+
+        builder.Property(configuration => configuration.Summary)
+            .HasMaxLength(280);
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/PortfolioDbContext.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Data/PortfolioDbContext.cs
@@ -20,6 +20,8 @@ public sealed class PortfolioDbContext(DbContextOptions<PortfolioDbContext> opti
 
     public DbSet<PortfolioSocialLink> PortfolioSocialLinks => Set<PortfolioSocialLink>();
 
+    public DbSet<ResumeConfiguration> ResumeConfigurations => Set<ResumeConfiguration>();
+
     public DbSet<Project> Projects => Set<Project>();
 
     public DbSet<ProjectCollaborator> ProjectCollaborators => Set<ProjectCollaborator>();

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeConfiguration.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeConfiguration.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProjectPortfolio2026.Server.Domain.Portfolio;
+
+public sealed class ResumeConfiguration
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(30)]
+    public string SourceType { get; set; } = ResumeSourceTypes.None;
+
+    [MaxLength(2048)]
+    public string? SourceUrl { get; set; }
+
+    [MaxLength(120)]
+    public string? DisplayLabel { get; set; }
+
+    [MaxLength(280)]
+    public string? Summary { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeConfigurationRules.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeConfigurationRules.cs
@@ -1,0 +1,62 @@
+namespace ProjectPortfolio2026.Server.Domain.Portfolio;
+
+public static class ResumeConfigurationRules
+{
+    public static IReadOnlyDictionary<string, string[]> Validate(string? sourceType, string? sourceUrl, string? displayLabel)
+    {
+        var normalizedSourceType = ResumeSourceTypes.Normalize(sourceType);
+        var trimmedSourceUrl = NormalizeText(sourceUrl);
+        var trimmedDisplayLabel = NormalizeText(displayLabel);
+        var errors = new Dictionary<string, string[]>();
+
+        if (!ResumeSourceTypes.IsSupported(sourceType))
+        {
+            errors["sourceType"] = ["Select a supported resume source type."];
+        }
+
+        if (normalizedSourceType == ResumeSourceTypes.None)
+        {
+            return errors;
+        }
+
+        if (string.IsNullOrWhiteSpace(trimmedSourceUrl))
+        {
+            errors["sourceUrl"] = ["A resume source URL is required when a hosted or embedded source is enabled."];
+        }
+        else if (!IsAbsoluteHttpUrl(trimmedSourceUrl))
+        {
+            errors["sourceUrl"] = ["Resume source URLs must use an absolute http or https address."];
+        }
+
+        if (string.IsNullOrWhiteSpace(trimmedDisplayLabel))
+        {
+            errors["displayLabel"] = ["A public display label is required when a resume source is enabled."];
+        }
+
+        return errors;
+    }
+
+    public static bool HasCompletePublicConfiguration(ResumeConfiguration? configuration)
+    {
+        if (configuration is null)
+        {
+            return false;
+        }
+
+        return Validate(configuration.SourceType, configuration.SourceUrl, configuration.DisplayLabel).Count == 0
+            && ResumeSourceTypes.Normalize(configuration.SourceType) != ResumeSourceTypes.None;
+    }
+
+    public static bool IsAbsoluteHttpUrl(string value)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string? NormalizeText(string? value)
+    {
+        var trimmedValue = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmedValue) ? null : trimmedValue;
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeSourceTypes.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeSourceTypes.cs
@@ -1,0 +1,26 @@
+namespace ProjectPortfolio2026.Server.Domain.Portfolio;
+
+public static class ResumeSourceTypes
+{
+    public const string None = "none";
+    public const string HostedFile = "hosted-file";
+    public const string Embed = "embed";
+
+    public static bool IsSupported(string? value)
+    {
+        var normalizedValue = Normalize(value);
+        return normalizedValue is None or HostedFile or Embed;
+    }
+
+    public static string Normalize(string? value)
+    {
+        var normalizedValue = value?.Trim().ToLowerInvariant();
+
+        return normalizedValue switch
+        {
+            HostedFile => HostedFile,
+            Embed => Embed,
+            _ => None
+        };
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeSourceTypes.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Domain/Portfolio/ResumeSourceTypes.cs
@@ -8,7 +8,7 @@ public static class ResumeSourceTypes
 
     public static bool IsSupported(string? value)
     {
-        var normalizedValue = Normalize(value);
+        var normalizedValue = value?.Trim().ToLowerInvariant();
         return normalizedValue is None or HostedFile or Embed;
     }
 

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/ResumeConfigurationContractMapper.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/ResumeConfigurationContractMapper.cs
@@ -1,0 +1,21 @@
+using ProjectPortfolio2026.Server.Contracts.Resume;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Mappers;
+
+public static class ResumeConfigurationContractMapper
+{
+    public static ResumeConfigurationResponse ToResponse(this ResumeConfiguration configuration, string? requestId = null)
+    {
+        return new ResumeConfigurationResponse
+        {
+            RequestId = requestId,
+            Id = configuration.Id,
+            SourceType = ResumeSourceTypes.Normalize(configuration.SourceType),
+            SourceUrl = ResumeConfigurationRules.NormalizeText(configuration.SourceUrl),
+            DisplayLabel = ResumeConfigurationRules.NormalizeText(configuration.DisplayLabel),
+            Summary = ResumeConfigurationRules.NormalizeText(configuration.Summary),
+            IsConfigured = ResumeConfigurationRules.HasCompletePublicConfiguration(configuration)
+        };
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260527111029_AddResumeConfiguration.Designer.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260527111029_AddResumeConfiguration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ProjectPortfolio2026.Server.Data;
 
@@ -11,9 +12,11 @@ using ProjectPortfolio2026.Server.Data;
 namespace ProjectPortfolio2026.Server.Migrations
 {
     [DbContext(typeof(PortfolioDbContext))]
-    partial class PortfolioDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527111029_AddResumeConfiguration")]
+    partial class AddResumeConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260527111029_AddResumeConfiguration.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Migrations/20260527111029_AddResumeConfiguration.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectPortfolio2026.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddResumeConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ResumeConfigurations",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SourceType = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false, defaultValue: "none"),
+                    SourceUrl = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    DisplayLabel = table.Column<string>(type: "nvarchar(120)", maxLength: 120, nullable: true),
+                    Summary = table.Column<string>(type: "nvarchar(280)", maxLength: 280, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ResumeConfigurations", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ResumeConfigurations");
+        }
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Program.cs
@@ -81,6 +81,7 @@ builder.Services
     });
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<IPortfolioProfileRepository, PortfolioProfileRepository>();
+builder.Services.AddScoped<IResumeConfigurationRepository, ResumeConfigurationRepository>();
 builder.Services.AddScoped<IPortfolioLinkFormatter, PortfolioLinkFormatter>();
 builder.Services.AddScoped<IProjectTagNormalizer, ProjectTagNormalizer>();
 builder.Services.AddScoped<IFeaturedProjectSelector, FeaturedProjectSelector>();

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/IResumeConfigurationRepository.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/IResumeConfigurationRepository.cs
@@ -1,0 +1,10 @@
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Repositories;
+
+public interface IResumeConfigurationRepository
+{
+    Task<ResumeConfiguration?> GetAsync(CancellationToken cancellationToken = default);
+
+    Task<ResumeConfiguration> SaveAsync(ResumeConfiguration configuration, CancellationToken cancellationToken = default);
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/ResumeConfigurationRepository.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/ResumeConfigurationRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using ProjectPortfolio2026.Server.Data;
 using ProjectPortfolio2026.Server.Domain.Portfolio;
+using System.Data;
 
 namespace ProjectPortfolio2026.Server.Repositories;
 
@@ -15,24 +16,37 @@ public sealed class ResumeConfigurationRepository(PortfolioDbContext dbContext) 
 
     public async Task<ResumeConfiguration> SaveAsync(ResumeConfiguration configuration, CancellationToken cancellationToken = default)
     {
+        var transaction = dbContext.Database.IsRelational()
+            ? await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
+            : null;
+
+        await using (transaction)
+        {
         var existingConfiguration = await dbContext.ResumeConfigurations
             .OrderByDescending(record => record.Id)
             .FirstOrDefaultAsync(cancellationToken);
 
-        if (existingConfiguration is null)
-        {
-            dbContext.ResumeConfigurations.Add(configuration);
-        }
-        else
-        {
-            existingConfiguration.SourceType = configuration.SourceType;
-            existingConfiguration.SourceUrl = configuration.SourceUrl;
-            existingConfiguration.DisplayLabel = configuration.DisplayLabel;
-            existingConfiguration.Summary = configuration.Summary;
-            configuration = existingConfiguration;
-        }
+            if (existingConfiguration is null)
+            {
+                dbContext.ResumeConfigurations.Add(configuration);
+            }
+            else
+            {
+                existingConfiguration.SourceType = configuration.SourceType;
+                existingConfiguration.SourceUrl = configuration.SourceUrl;
+                existingConfiguration.DisplayLabel = configuration.DisplayLabel;
+                existingConfiguration.Summary = configuration.Summary;
+                configuration = existingConfiguration;
+            }
 
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return configuration;
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            if (transaction is not null)
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
+
+            return configuration;
+        }
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/ResumeConfigurationRepository.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Repositories/ResumeConfigurationRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using ProjectPortfolio2026.Server.Data;
+using ProjectPortfolio2026.Server.Domain.Portfolio;
+
+namespace ProjectPortfolio2026.Server.Repositories;
+
+public sealed class ResumeConfigurationRepository(PortfolioDbContext dbContext) : IResumeConfigurationRepository
+{
+    public async Task<ResumeConfiguration?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.ResumeConfigurations
+            .OrderByDescending(configuration => configuration.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<ResumeConfiguration> SaveAsync(ResumeConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        var existingConfiguration = await dbContext.ResumeConfigurations
+            .OrderByDescending(record => record.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existingConfiguration is null)
+        {
+            dbContext.ResumeConfigurations.Add(configuration);
+        }
+        else
+        {
+            existingConfiguration.SourceType = configuration.SourceType;
+            existingConfiguration.SourceUrl = configuration.SourceUrl;
+            existingConfiguration.DisplayLabel = configuration.DisplayLabel;
+            existingConfiguration.Summary = configuration.Summary;
+            configuration = existingConfiguration;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return configuration;
+    }
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -824,10 +824,36 @@
     box-sizing: border-box;
 }
 
+.auth-field select,
+.auth-field textarea {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border: 1px solid rgba(111, 137, 171, 0.18);
+    border-radius: 0.95rem;
+    background: rgba(8, 17, 31, 0.82);
+    color: #f4f8fe;
+    box-sizing: border-box;
+    font: inherit;
+}
+
 .auth-field input:focus {
     outline: none;
     border-color: rgba(99, 222, 255, 0.62);
     box-shadow: 0 0 0 0.22rem rgba(99, 222, 255, 0.12);
+}
+
+.auth-field select:focus,
+.auth-field textarea:focus {
+    outline: none;
+    border-color: rgba(99, 222, 255, 0.62);
+    box-shadow: 0 0 0 0.22rem rgba(99, 222, 255, 0.12);
+}
+
+.auth-field input:disabled,
+.auth-field select:disabled,
+.auth-field textarea:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
 .auth-helper {
@@ -920,6 +946,30 @@
 .admin-dashboard-grid {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
     gap: 1rem;
+}
+
+.admin-resume-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+    gap: 1rem;
+}
+
+.admin-form,
+.admin-note-panel,
+.admin-form-grid,
+.admin-note-stack {
+    gap: 0.85rem;
+}
+
+.admin-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+}
+
+.admin-note-stack {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
 }
 
 .admin-section-link {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -371,6 +371,18 @@ describe('App', () => {
                 });
             }
 
+            if (url === '/api/resume-configuration?requestId=request-1') {
+                return jsonResponse({
+                    requestId: 'request-1',
+                    id: 1,
+                    sourceType: 'hosted-file',
+                    sourceUrl: 'https://cdn.example.dev/resume.pdf',
+                    displayLabel: 'Download Resume',
+                    summary: 'ATS-friendly PDF.',
+                    isConfigured: true
+                });
+            }
+
             throw new Error(`Unexpected fetch request: ${url}`);
         });
 
@@ -389,7 +401,8 @@ describe('App', () => {
         expect(screen.getByRole('button', { name: 'Top 3' })).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByRole('button', { name: 'Top 5' })).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
-        expect(screen.getByRole('button', { name: 'Open Static Resume' })).toBeDisabled();
+        expect(screen.getByRole('link', { name: 'Download Resume' })).toHaveAttribute('href', 'https://cdn.example.dev/resume.pdf');
+        expect(screen.getByText('ATS-friendly PDF.')).toBeInTheDocument();
     });
 
     it('renders the contact page from the portfolio profile endpoint and highlights contact navigation', async () => {
@@ -994,6 +1007,21 @@ describe('App', () => {
             email: 'admin@example.com',
             displayName: 'admin'
         });
+        queueFetchJson('/api/auth/me', {
+            isAuthenticated: true,
+            isAdmin: true,
+            userName: 'admin',
+            email: 'admin@example.com',
+            displayName: 'admin'
+        });
+        queueFetchJson('/api/admin/resume-configuration', {
+            id: 0,
+            sourceType: 'none',
+            sourceUrl: null,
+            displayLabel: null,
+            summary: null,
+            isConfigured: false
+        });
         render(<App />);
 
         fireEvent.change(screen.getByLabelText('Username or email'), {
@@ -1014,7 +1042,7 @@ describe('App', () => {
 
         fireEvent.click(screen.getByRole('link', { name: 'Open Resume Configuration' }));
 
-        expect(await screen.findByRole('heading', { name: 'Resume configuration can build on a stable shell.' })).toBeInTheDocument();
+        expect(await screen.findByRole('heading', { name: 'Manage the public resume source' })).toBeInTheDocument();
         expect(window.location.pathname).toBe('/admin/resume');
     });
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.tsx
@@ -5,6 +5,7 @@ import { AccountSettingsPage } from './components/admin/AccountSettingsPage';
 import { getAdminSection } from './components/admin/adminSections';
 import { AdminWorkspacePage } from './components/admin/AdminWorkspacePage';
 import { LoginPage } from './components/admin/LoginPage';
+import { ResumeConfigurationSection } from './components/admin/ResumeConfigurationSection';
 import { type AccountDraft } from './components/admin/mockAuth';
 import { SiteShell, type SiteShellContent } from './components/shell/SiteShell';
 import { ContactPage } from './features/contact/ContactPage';
@@ -216,6 +217,7 @@ function App() {
                     activeSection={route.section}
                     currentUserDisplayName={displayName}
                     onNavigate={navigate}
+                    sectionContent={route.section === 'resume' ? <ResumeConfigurationSection /> : undefined}
                 />
             ) : route.kind === 'admin-account' && currentUser ? (
                 <AccountSettingsPage

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeConfiguration.test.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeConfiguration.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { saveResumeConfigurationAsync } from './resumeConfiguration';
+import { csrfCookieName, csrfHeaderName } from './http';
+
+const fetchMock = vi.fn<typeof fetch>();
+
+describe('resumeConfiguration api helpers', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', fetchMock);
+        document.cookie = `${csrfCookieName}=csrf-token-value`;
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+        document.cookie = `${csrfCookieName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    });
+
+    it('clears disabled fields when saving a none source configuration', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({
+            id: 1,
+            sourceType: 'none',
+            sourceUrl: null,
+            displayLabel: null,
+            summary: null,
+            isConfigured: false
+        }));
+
+        await saveResumeConfigurationAsync({
+            sourceType: 'none',
+            sourceUrl: ' https://cdn.example.dev/resume.pdf ',
+            displayLabel: ' Download Resume ',
+            summary: ' Hidden resume link '
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('/api/admin/resume-configuration', expect.objectContaining({
+            credentials: 'include',
+            method: 'PUT',
+            headers: expect.any(Headers)
+        }));
+
+        const [, options] = fetchMock.mock.calls[0];
+        const headers = options?.headers as Headers;
+
+        expect(headers.get('Content-Type')).toBe('application/json');
+        expect(headers.get(csrfHeaderName)).toBe('csrf-token-value');
+        expect(options?.body).toBe(JSON.stringify({
+            sourceType: 'none',
+            sourceUrl: null,
+            displayLabel: null,
+            summary: null
+        }));
+    });
+});
+
+function jsonResponse(payload: object) {
+    return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeConfiguration.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeConfiguration.ts
@@ -1,0 +1,74 @@
+import {
+    fetchAuthJson,
+    fetchResponsePayloadWithStartupRetry,
+    RetryableApiError,
+    startupRetryMessage
+} from './http';
+import type { ResumeConfiguration, ResumeSourceType } from '../app/types';
+
+export interface ResumeConfigurationDraft {
+    sourceType: ResumeSourceType;
+    sourceUrl: string;
+    displayLabel: string;
+    summary: string;
+}
+
+export async function fetchPublicResumeConfiguration(signal: AbortSignal) {
+    const requestId = crypto.randomUUID();
+    const query = new URLSearchParams({ requestId });
+    const { response, payload } = await fetchResponsePayloadWithStartupRetry<ResumeConfiguration>(
+        `/api/resume-configuration?${query.toString()}`,
+        {
+            signal
+        },
+        'Unable to load the public resume source right now.',
+        [404]
+    );
+
+    if (response.status === 404) {
+        return {
+            isMissing: true,
+            configuration: null
+        };
+    }
+
+    if (payload === null) {
+        throw new RetryableApiError(startupRetryMessage);
+    }
+
+    return {
+        isMissing: false,
+        configuration: payload as ResumeConfiguration
+    };
+}
+
+export async function fetchAdminResumeConfiguration(signal?: AbortSignal) {
+    const { payload } = await fetchAuthJson<ResumeConfiguration>(
+        '/api/admin/resume-configuration',
+        {
+            method: 'GET',
+            signal
+        },
+        'Unable to load resume configuration.'
+    );
+
+    return payload as ResumeConfiguration | null;
+}
+
+export async function saveResumeConfigurationAsync(draft: ResumeConfigurationDraft) {
+    const { payload } = await fetchAuthJson<ResumeConfiguration>(
+        '/api/admin/resume-configuration',
+        {
+            method: 'PUT',
+            body: JSON.stringify({
+                sourceType: draft.sourceType,
+                sourceUrl: draft.sourceUrl.trim() || null,
+                displayLabel: draft.displayLabel.trim() || null,
+                summary: draft.summary.trim() || null
+            })
+        },
+        'Unable to save resume configuration.'
+    );
+
+    return payload as ResumeConfiguration | null;
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeConfiguration.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeConfiguration.ts
@@ -56,15 +56,16 @@ export async function fetchAdminResumeConfiguration(signal?: AbortSignal) {
 }
 
 export async function saveResumeConfigurationAsync(draft: ResumeConfigurationDraft) {
+    const clearsExternalSource = draft.sourceType === 'none';
     const { payload } = await fetchAuthJson<ResumeConfiguration>(
         '/api/admin/resume-configuration',
         {
             method: 'PUT',
             body: JSON.stringify({
                 sourceType: draft.sourceType,
-                sourceUrl: draft.sourceUrl.trim() || null,
-                displayLabel: draft.displayLabel.trim() || null,
-                summary: draft.summary.trim() || null
+                sourceUrl: clearsExternalSource ? null : draft.sourceUrl.trim() || null,
+                displayLabel: clearsExternalSource ? null : draft.displayLabel.trim() || null,
+                summary: clearsExternalSource ? null : draft.summary.trim() || null
             })
         },
         'Unable to save resume configuration.'

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/app/types.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/app/types.ts
@@ -127,6 +127,18 @@ export interface PortfolioProfile {
     socialLinks: PortfolioSocialLink[];
 }
 
+export type ResumeSourceType = 'none' | 'hosted-file' | 'embed';
+
+export interface ResumeConfiguration {
+    requestId?: string;
+    id: number;
+    sourceType: ResumeSourceType;
+    sourceUrl?: string | null;
+    displayLabel?: string | null;
+    summary?: string | null;
+    isConfigured: boolean;
+}
+
 export interface ApiErrorResponse {
     message?: string;
 }

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/AdminWorkspacePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/AdminWorkspacePage.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { NavigateFn } from '../../app/navigation';
 import { InternalLink } from '../common/InternalLink';
 import { adminSections, getAdminSection, type AdminSectionId } from './adminSections';
@@ -48,11 +49,13 @@ const sectionDetails: Record<Exclude<AdminSectionId, 'dashboard'>, { title: stri
 export function AdminWorkspacePage({
     activeSection,
     currentUserDisplayName,
-    onNavigate
+    onNavigate,
+    sectionContent
 }: {
     activeSection: AdminSectionId;
     currentUserDisplayName: string;
     onNavigate: NavigateFn;
+    sectionContent?: ReactNode;
 }) {
     const currentSection = getAdminSection(activeSection);
 
@@ -129,6 +132,8 @@ export function AdminWorkspacePage({
                                 </article>
                             ))}
                         </section>
+                    ) : sectionContent ? (
+                        sectionContent
                     ) : (
                         <article className="admin-card admin-section-panel">
                             <p className="eyebrow">{currentSection.kicker}</p>

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeConfigurationSection.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeConfigurationSection.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResumeConfigurationSection } from './ResumeConfigurationSection';
+
+vi.mock('../../api/resumeConfiguration', () => ({
+    fetchAdminResumeConfiguration: vi.fn(),
+    saveResumeConfigurationAsync: vi.fn()
+}));
+
+import {
+    fetchAdminResumeConfiguration,
+    saveResumeConfigurationAsync
+} from '../../api/resumeConfiguration';
+
+const mockFetchAdminResumeConfiguration = vi.mocked(fetchAdminResumeConfiguration);
+const mockSaveResumeConfigurationAsync = vi.mocked(saveResumeConfigurationAsync);
+
+describe('ResumeConfigurationSection', () => {
+    beforeEach(() => {
+        mockFetchAdminResumeConfiguration.mockResolvedValue({
+            id: 1,
+            sourceType: 'hosted-file',
+            sourceUrl: 'https://cdn.example.dev/resume.pdf',
+            displayLabel: 'Download Resume',
+            summary: 'ATS-friendly PDF.',
+            isConfigured: true
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('loads the saved admin configuration into the form', async () => {
+        render(<ResumeConfigurationSection />);
+
+        expect(await screen.findByDisplayValue('https://cdn.example.dev/resume.pdf')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Download Resume')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('ATS-friendly PDF.')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Visible from the public resume page' })).toBeInTheDocument();
+    });
+
+    it('validates required fields before saving an enabled source', async () => {
+        mockFetchAdminResumeConfiguration.mockResolvedValue({
+            id: 0,
+            sourceType: 'none',
+            sourceUrl: null,
+            displayLabel: null,
+            summary: null,
+            isConfigured: false
+        });
+
+        render(<ResumeConfigurationSection />);
+
+        await screen.findByRole('button', { name: 'Save Resume Configuration' });
+        fireEvent.change(screen.getByLabelText('Source type'), {
+            target: { value: 'embed' }
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Resume Configuration' }));
+
+        expect(await screen.findByText('A resume source URL is required when a hosted or embedded source is enabled.')).toBeInTheDocument();
+        expect(mockSaveResumeConfigurationAsync).not.toHaveBeenCalled();
+    });
+
+    it('saves the edited configuration and surfaces a success notice', async () => {
+        mockSaveResumeConfigurationAsync.mockResolvedValue({
+            id: 1,
+            sourceType: 'embed',
+            sourceUrl: 'https://drive.example.dev/embed/resume',
+            displayLabel: 'Open Embedded Resume',
+            summary: 'External embed-ready source.',
+            isConfigured: true
+        });
+
+        render(<ResumeConfigurationSection />);
+
+        await screen.findByDisplayValue('https://cdn.example.dev/resume.pdf');
+
+        fireEvent.change(screen.getByLabelText('Source type'), {
+            target: { value: 'embed' }
+        });
+        fireEvent.change(screen.getByLabelText('Source URL'), {
+            target: { value: 'https://drive.example.dev/embed/resume' }
+        });
+        fireEvent.change(screen.getByLabelText('Public label'), {
+            target: { value: 'Open Embedded Resume' }
+        });
+        fireEvent.change(screen.getByLabelText('Public summary'), {
+            target: { value: 'External embed-ready source.' }
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Resume Configuration' }));
+
+        await waitFor(() => {
+            expect(mockSaveResumeConfigurationAsync).toHaveBeenCalledWith({
+                sourceType: 'embed',
+                sourceUrl: 'https://drive.example.dev/embed/resume',
+                displayLabel: 'Open Embedded Resume',
+                summary: 'External embed-ready source.'
+            });
+        });
+
+        expect(await screen.findByText('Resume configuration saved.')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Visible from the public resume page' })).toBeInTheDocument();
+    });
+});

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeConfigurationSection.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeConfigurationSection.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState, type SyntheticEvent } from 'react';
+import {
+    fetchAdminResumeConfiguration,
+    saveResumeConfigurationAsync,
+    type ResumeConfigurationDraft
+} from '../../api/resumeConfiguration';
+import type { ResumeConfiguration, ResumeSourceType } from '../../app/types';
+
+const emptyDraft: ResumeConfigurationDraft = {
+    sourceType: 'none',
+    sourceUrl: '',
+    displayLabel: '',
+    summary: ''
+};
+
+function createDraft(configuration: ResumeConfiguration | null): ResumeConfigurationDraft {
+    if (!configuration) {
+        return emptyDraft;
+    }
+
+    return {
+        sourceType: configuration.sourceType,
+        sourceUrl: configuration.sourceUrl ?? '',
+        displayLabel: configuration.displayLabel ?? '',
+        summary: configuration.summary ?? ''
+    };
+}
+
+function validateDraft(draft: ResumeConfigurationDraft) {
+    if (draft.sourceType === 'none') {
+        return null;
+    }
+
+    if (!draft.sourceUrl.trim()) {
+        return 'A resume source URL is required when a hosted or embedded source is enabled.';
+    }
+
+    try {
+        const parsedUrl = new URL(draft.sourceUrl.trim());
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+            return 'Resume source URLs must use an absolute http or https address.';
+        }
+    } catch {
+        return 'Resume source URLs must use an absolute http or https address.';
+    }
+
+    if (!draft.displayLabel.trim()) {
+        return 'A public display label is required when a resume source is enabled.';
+    }
+
+    return null;
+}
+
+function getSourceTypeSummary(sourceType: ResumeSourceType) {
+    return sourceType === 'embed'
+        ? 'Embed-style sources stay off-page here and open externally from the public resume.'
+        : sourceType === 'hosted-file'
+            ? 'Hosted files are exposed as an external resume action from the public page.'
+            : 'No external resume source will be shown publicly.';
+}
+
+export function ResumeConfigurationSection() {
+    const [draft, setDraft] = useState<ResumeConfigurationDraft>(emptyDraft);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+    const [isConfigured, setIsConfigured] = useState(false);
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        setIsLoading(true);
+        setError(null);
+
+        void loadConfiguration();
+
+        return () => controller.abort();
+
+        async function loadConfiguration() {
+            try {
+                const configuration = await fetchAdminResumeConfiguration(controller.signal);
+                if (controller.signal.aborted) {
+                    return;
+                }
+
+                setDraft(createDraft(configuration));
+                setIsConfigured(configuration?.isConfigured ?? false);
+            } catch (caughtError) {
+                if ((caughtError as Error).name === 'AbortError') {
+                    return;
+                }
+
+                setError(caughtError instanceof Error ? caughtError.message : 'Unable to load resume configuration.');
+            } finally {
+                setIsLoading(false);
+            }
+        }
+    }, []);
+
+    async function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        const validationError = validateDraft(draft);
+        if (validationError) {
+            setError(validationError);
+            setNotice(null);
+            return;
+        }
+
+        setIsSaving(true);
+        setError(null);
+        setNotice(null);
+
+        try {
+            const savedConfiguration = await saveResumeConfigurationAsync(draft);
+            setDraft(createDraft(savedConfiguration));
+            setIsConfigured(savedConfiguration?.isConfigured ?? false);
+            setNotice('Resume configuration saved.');
+        } catch (caughtError) {
+            setError(caughtError instanceof Error ? caughtError.message : 'Unable to save resume configuration.');
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    const sourceTypeSummary = getSourceTypeSummary(draft.sourceType);
+
+    return (
+        <section className="admin-resume-grid">
+            <form className="admin-card admin-form" onSubmit={handleSubmit}>
+                <p className="eyebrow">Resume Configuration</p>
+                <h2>Manage the public resume source</h2>
+                <p>
+                    Configure the optional external resume action without tying it to broader profile or publishing workflows.
+                </p>
+
+                <div className="admin-form-grid">
+                    <label className="auth-field">
+                        <span>Source type</span>
+                        <select
+                            value={draft.sourceType}
+                            onChange={event => {
+                                const nextSourceType = event.target.value as ResumeSourceType;
+                                setDraft(current => ({
+                                    ...current,
+                                    sourceType: nextSourceType
+                                }));
+                            }}>
+                            <option value="none">No external source</option>
+                            <option value="hosted-file">Hosted file</option>
+                            <option value="embed">Embed source</option>
+                        </select>
+                    </label>
+
+                    <label className="auth-field">
+                        <span>Source URL</span>
+                        <input
+                            type="url"
+                            value={draft.sourceUrl}
+                            onChange={event => setDraft(current => ({ ...current, sourceUrl: event.target.value }))}
+                            placeholder="https://example.com/resume.pdf"
+                            disabled={draft.sourceType === 'none'}
+                        />
+                    </label>
+
+                    <label className="auth-field">
+                        <span>Public label</span>
+                        <input
+                            type="text"
+                            value={draft.displayLabel}
+                            onChange={event => setDraft(current => ({ ...current, displayLabel: event.target.value }))}
+                            placeholder="Download Resume"
+                            disabled={draft.sourceType === 'none'}
+                        />
+                    </label>
+
+                    <label className="auth-field">
+                        <span>Public summary</span>
+                        <textarea
+                            value={draft.summary}
+                            onChange={event => setDraft(current => ({ ...current, summary: event.target.value }))}
+                            placeholder="ATS-friendly PDF for recruiters who prefer a file download."
+                            rows={4}
+                            disabled={draft.sourceType === 'none'}
+                        />
+                    </label>
+                </div>
+
+                {error ? <p className="status-banner error">{error}</p> : null}
+                {notice ? <p className="status-banner">{notice}</p> : null}
+                {isLoading ? <p className="secondary-copy">Loading saved resume configuration...</p> : null}
+
+                <button className="primary-action" type="submit" disabled={isLoading || isSaving}>
+                    {isSaving ? 'Saving Resume Configuration...' : 'Save Resume Configuration'}
+                </button>
+            </form>
+
+            <aside className="admin-card admin-note-panel">
+                <p className="eyebrow">Public Visibility</p>
+                <h2>{isConfigured ? 'Visible from the public resume page' : 'Hidden until configuration is complete'}</h2>
+                <p>{sourceTypeSummary}</p>
+
+                <div className="admin-note-stack">
+                    <div>
+                        <span className="stat-label">Current mode</span>
+                        <strong>{draft.sourceType === 'none' ? 'No external source' : draft.sourceType === 'embed' ? 'Embed source' : 'Hosted file'}</strong>
+                    </div>
+                    <div>
+                        <span className="stat-label">Label</span>
+                        <strong>{draft.displayLabel.trim() || 'Not set yet'}</strong>
+                    </div>
+                    <div>
+                        <span className="stat-label">Summary</span>
+                        <strong>{draft.summary.trim() || 'No helper copy yet'}</strong>
+                    </div>
+                </div>
+            </aside>
+        </section>
+    );
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Employer, PortfolioProfile } from '../../app/types';
+import type { Employer, PortfolioProfile, ResumeConfiguration } from '../../app/types';
 import { ResumePage } from './ResumePage';
 
 vi.mock('../../hooks/usePortfolioProfile', () => ({
@@ -11,10 +11,16 @@ vi.mock('../../hooks/useWorkHistory', () => ({
     useWorkHistory: vi.fn()
 }));
 
+vi.mock('../../hooks/useResumeConfiguration', () => ({
+    useResumeConfiguration: vi.fn()
+}));
+
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
+import { useResumeConfiguration } from '../../hooks/useResumeConfiguration';
 import { useWorkHistory } from '../../hooks/useWorkHistory';
 
 const mockUsePortfolioProfile = vi.mocked(usePortfolioProfile);
+const mockUseResumeConfiguration = vi.mocked(useResumeConfiguration);
 const mockUseWorkHistory = vi.mocked(useWorkHistory);
 
 function createProfile(overrides: Partial<PortfolioProfile> = {}): PortfolioProfile {
@@ -51,6 +57,18 @@ function createEmployer(id: number, overrides: Partial<Employer> = {}): Employer
     };
 }
 
+function createResumeConfiguration(overrides: Partial<ResumeConfiguration> = {}): ResumeConfiguration {
+    return {
+        id: 1,
+        sourceType: 'hosted-file',
+        sourceUrl: 'https://cdn.example.dev/resume.pdf',
+        displayLabel: 'Download Resume',
+        summary: 'ATS-friendly PDF.',
+        isConfigured: true,
+        ...overrides
+    };
+}
+
 describe('ResumePage', () => {
     afterEach(() => {
         cleanup();
@@ -71,6 +89,12 @@ describe('ResumePage', () => {
             employers: [createEmployer(1)],
             isLoading: false,
             error: null
+        });
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: createResumeConfiguration(),
+            isLoading: false,
+            error: null,
+            isMissing: false
         });
     });
 
@@ -140,6 +164,12 @@ describe('ResumePage', () => {
             isLoading: false,
             error: null
         });
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: null,
+            isLoading: false,
+            error: null,
+            isMissing: true
+        });
 
         render(<ResumePage />);
 
@@ -150,6 +180,14 @@ describe('ResumePage', () => {
         expect(screen.getByText('Published work history will appear here once employer and job-role records are available.')).toBeInTheDocument();
         expect(screen.queryByRole('heading', { name: 'Positioning for recruiters and hiring teams.' })).not.toBeInTheDocument();
         expect(screen.queryByRole('heading', { name: 'Highlighted skills and technologies.' })).not.toBeInTheDocument();
+    });
+
+    it('renders the configured public resume action when external source settings are available', () => {
+        render(<ResumePage />);
+
+        expect(screen.getByRole('link', { name: 'Download Resume' })).toHaveAttribute('href', 'https://cdn.example.dev/resume.pdf');
+        expect(screen.getByText('ATS-friendly PDF.')).toBeInTheDocument();
+        expect(screen.getAllByText('Hosted file').length).toBeGreaterThan(0);
     });
 
     it('renders structured summary, skill highlights, and full experience history', () => {
@@ -352,6 +390,12 @@ describe('ResumePage', () => {
             isLoading: true,
             error: null
         });
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: null,
+            isLoading: true,
+            error: null,
+            isMissing: false
+        });
 
         const { rerender } = render(<ResumePage />);
 
@@ -368,12 +412,19 @@ describe('ResumePage', () => {
             isLoading: false,
             error: 'Work history request failed.'
         });
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: null,
+            isLoading: false,
+            error: 'Resume configuration failed.',
+            isMissing: false
+        });
 
         rerender(<ResumePage />);
 
         expect(screen.queryByText('Loading resume...')).not.toBeInTheDocument();
         expect(screen.getByText('Profile request failed.')).toBeInTheDocument();
         expect(screen.getByText('Work history request failed.')).toBeInTheDocument();
+        expect(screen.getByText('Resume configuration failed.')).toBeInTheDocument();
     });
 
     it('avoids duplicate key warnings when role titles and start dates repeat', () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { JobRole } from '../../app/types';
 import { formatProjectDates } from '../../appSupport';
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
+import { useResumeConfiguration } from '../../hooks/useResumeConfiguration';
 import { useWorkHistory } from '../../hooks/useWorkHistory';
 
 interface ResumeDateValue {
@@ -308,6 +309,12 @@ export function ResumePage() {
         isLoading: isWorkHistoryLoading,
         error: workHistoryError
     } = useWorkHistory();
+    const {
+        configuration: resumeConfiguration,
+        isLoading: isResumeConfigurationLoading,
+        error: resumeConfigurationError,
+        isMissing: isResumeConfigurationMissing
+    } = useResumeConfiguration();
 
     const currentDate = new Date();
     const currentMonthIndex = (currentDate.getFullYear() * 12) + currentDate.getMonth() + 1;
@@ -359,8 +366,8 @@ export function ResumePage() {
     const highlightedTechnologySet = new Set(technologyHighlights.map(highlight => highlight.label));
     const hasSummarySection = Boolean(profile?.contactHeadline?.trim() || profile?.availabilityHeadline?.trim() || summaryParagraphs.length > 0);
     const hasSkillsSection = skillHighlights.length > 0 || technologyHighlights.length > 0;
-    const isLoading = isProfileLoading || isWorkHistoryLoading;
-    const errors = [profileError, workHistoryError].filter(Boolean);
+    const isLoading = isProfileLoading || isWorkHistoryLoading || isResumeConfigurationLoading;
+    const errors = [profileError, workHistoryError, resumeConfigurationError].filter(Boolean);
     const activeFilterCount = (selectedTimeFilter.key === 'all' ? 0 : 1) + (selectedEmployerLimit.key === 'all' ? 0 : 1);
     const resumeViewSummary = getResumeViewSummary(
         selectedTimeFilter,
@@ -369,6 +376,7 @@ export function ResumePage() {
         filteredRoleCount,
         totalRoleCount
     );
+    const resumeSourceTypeLabel = resumeConfiguration?.sourceType === 'embed' ? 'Embed source' : 'Hosted file';
 
     return (
         <main className="resume-page">
@@ -507,18 +515,39 @@ export function ResumePage() {
                         </div>
                         <div className="resume-action-card">
                             <div className="resume-action-copy">
-                                <span className="meta-label">Static Resume Link</span>
-                                <span className="resume-action-note">{isProfileMissing ? 'Needs config' : 'Planned'}</span>
+                                <span className="meta-label">Resume Source</span>
+                                <span className="resume-action-note">
+                                    {resumeConfiguration?.isConfigured
+                                        ? resumeSourceTypeLabel
+                                        : isResumeConfigurationMissing || isProfileMissing
+                                            ? 'Needs config'
+                                            : 'Unavailable'}
+                                </span>
                             </div>
-                            <button
-                                className="resume-action-button"
-                                type="button"
-                                disabled
-                                aria-disabled="true"
-                                aria-label="Open Static Resume">
-                                <span>Open Static Resume</span>
-                                <span className="coming-soon-pill">Coming Soon</span>
-                            </button>
+                            {resumeConfiguration?.isConfigured && resumeConfiguration.sourceUrl && resumeConfiguration.displayLabel ? (
+                                <a
+                                    className="resume-action-button"
+                                    href={resumeConfiguration.sourceUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    aria-label={resumeConfiguration.displayLabel}>
+                                    <span>{resumeConfiguration.displayLabel}</span>
+                                    <span className="coming-soon-pill">{resumeSourceTypeLabel}</span>
+                                </a>
+                            ) : (
+                                <button
+                                    className="resume-action-button"
+                                    type="button"
+                                    disabled
+                                    aria-disabled="true"
+                                    aria-label="Open Resume Source">
+                                    <span>Open Resume Source</span>
+                                    <span className="coming-soon-pill">Needs Config</span>
+                                </button>
+                            )}
+                            {resumeConfiguration?.isConfigured && resumeConfiguration.summary ? (
+                                <p>{resumeConfiguration.summary}</p>
+                            ) : null}
                         </div>
                     </div>
                 </article>

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/hooks/useResumeConfiguration.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/hooks/useResumeConfiguration.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { fetchPublicResumeConfiguration } from '../api/resumeConfiguration';
+import type { ResumeConfiguration } from '../app/types';
+
+interface UseResumeConfigurationResult {
+    configuration: ResumeConfiguration | null;
+    isLoading: boolean;
+    error: string | null;
+    isMissing: boolean;
+}
+
+export function useResumeConfiguration(): UseResumeConfigurationResult {
+    const [configuration, setConfiguration] = useState<ResumeConfiguration | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [isMissing, setIsMissing] = useState(false);
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        setIsLoading(true);
+        setError(null);
+        setIsMissing(false);
+
+        void loadConfiguration();
+
+        return () => controller.abort();
+
+        async function loadConfiguration() {
+            try {
+                const result = await fetchPublicResumeConfiguration(controller.signal);
+                setIsMissing(result.isMissing);
+                setConfiguration(result.configuration);
+            } catch (caughtError) {
+                if ((caughtError as Error).name === 'AbortError') {
+                    return;
+                }
+
+                setConfiguration(null);
+                setError(caughtError instanceof Error ? caughtError.message : 'Unable to load the public resume source right now.');
+            } finally {
+                setIsLoading(false);
+            }
+        }
+    }, []);
+
+    return {
+        configuration,
+        isLoading,
+        error,
+        isMissing
+    };
+}


### PR DESCRIPTION
Addresses #67

## Summary
- add a dedicated resume configuration persistence model, migration, repository, and admin/public API endpoints
- replace the `/admin/resume` placeholder with a working admin form for source type, URL, label, and summary management
- wire the public `/resume` page to surface the configured external resume source only when the configuration is complete
- add server and client tests that cover repository behavior, controller validation, admin UI state, and public resume rendering

## Verification
- `dotnet test ProjectPortfolio2026\ProjectPortfolio2026.Server.Tests\ProjectPortfolio2026.Server.Tests.csproj -c Release`
- `npm test`
- `npm run build`