### PR TITLE
Daily unit test: cover resume import source filename preservation

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportServiceTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportServiceTests.cs
@@ -47,6 +47,32 @@ public sealed class ResumeImportServiceTests
     }
 
     [Test]
+    public async Task ParseAsync_PreservesParserSuppliedSourceFileName()
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var parser = new TrackingResumeParserService
+        {
+            ResultFactory = () => new ResumeImportParseResult
+            {
+                SourceFileName = "normalized-resume.pdf",
+                ParserName = "TrackingResumeParserService"
+            }
+        };
+        var service = new ResumeImportService(store, parser);
+        var file = CreateFormFile("resume.pdf", "application/pdf", [9, 8, 7]);
+
+        var result = await service.ParseAsync(file);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.SourceFileName, Is.EqualTo("normalized-resume.pdf"));
+            Assert.That(parser.CapturedFileName, Is.EqualTo("resume.pdf"));
+            Assert.That(Directory.Exists(tempRootPath), Is.True);
+            Assert.That(Directory.EnumerateFiles(tempRootPath), Is.Empty);
+        });
+    }
+
+    [Test]
     public void ParseAsync_DeletesTemporaryUploadWhenParserFails()
     {
         var store = new TemporaryResumeFileStore(tempRootPath);
@@ -77,6 +103,11 @@ public sealed class ResumeImportServiceTests
 
         public string? CapturedFileName { get; private set; }
 
+        public Func<ResumeImportParseResult> ResultFactory { get; set; } = () => new ResumeImportParseResult
+        {
+            ParserName = "TrackingResumeParserService"
+        };
+
         public async Task<ResumeImportParseResult> ParseAsync(
             Stream content,
             string fileName,
@@ -87,10 +118,7 @@ public sealed class ResumeImportServiceTests
             CapturedBytes = memoryStream.ToArray();
             CapturedFileName = fileName;
 
-            return new ResumeImportParseResult
-            {
-                ParserName = "TrackingResumeParserService"
-            };
+            return ResultFactory();
         }
     }
 


### PR DESCRIPTION
Addresses the daily unit test automation task for recent resume import changes.

## Summary
- add coverage for the `ResumeImportService` path that preserves a parser-supplied `SourceFileName`
- keep the test scoped to the existing resume import staging flow
- verify the server test project passes in Release configuration

## Verification
- `dotnet test ProjectPortfolio2026.Server.Tests\ProjectPortfolio2026.Server.Tests.csproj -c Release`
