### PR TITLE
Test gap: cover missing terminal resume file names

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/TemporaryResumeFileStoreTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/TemporaryResumeFileStoreTests.cs
@@ -82,6 +82,18 @@ public sealed class TemporaryResumeFileStoreTests
         Assert.That(exception?.Message, Is.EqualTo("A resume file is required."));
     }
 
+    [TestCase("temp/")]
+    [TestCase(@"temp\")]
+    public void StageAsync_RejectsPathWithoutTerminalFileName(string uploadedFileName)
+    {
+        var store = new TemporaryResumeFileStore(tempRootPath);
+        var file = CreateFormFile(uploadedFileName, "application/pdf", [1, 2, 3]);
+
+        var exception = Assert.ThrowsAsync<ResumeImportValidationException>(async () => await store.StageAsync(file));
+
+        Assert.That(exception?.Message, Is.EqualTo("A resume file is required."));
+    }
+
     [Test]
     public void StageAsync_RejectsEmptyFiles()
     {


### PR DESCRIPTION
## Summary
- add regression coverage for upload names that contain only a directory segment
- verify both slash styles still surface the existing validation message
- keep scope limited to TemporaryResumeFileStore tests for the recent path sanitization change

## Verification
- dotnet test ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ProjectPortfolio2026.Server.Tests.csproj --filter TemporaryResumeFileStoreTests
