### PR TITLE
#125 Refine public project filter and search panel integration

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -2554,6 +2554,164 @@
     text-shadow: 0 1px 0 rgba(4, 11, 20, 0.35);
 }
 
+@media (min-width: 901px) and (max-width: 1450px), (min-width: 901px) and (max-height: 940px) {
+    .site-shell {
+        grid-template-columns: minmax(13.5rem, 16rem) minmax(0, 1fr);
+    }
+
+    .site-sidebar {
+        gap: 1rem;
+        padding: 1rem 0.85rem;
+    }
+
+    .site-brand {
+        gap: 0.75rem;
+        padding: 0.8rem 0.85rem;
+    }
+
+    .brand-mark {
+        width: 2.6rem;
+        border-radius: 0.85rem;
+    }
+
+    .site-brand strong {
+        font-size: 0.98rem;
+    }
+
+    .sidebar-welcome {
+        padding: 0.8rem 0.85rem;
+    }
+
+    .sidebar-welcome-name {
+        font-size: 1rem;
+    }
+
+    .nav-link {
+        min-height: 2.7rem;
+        padding: 0.72rem 0.85rem;
+        border-radius: 0.9rem;
+    }
+
+    .site-main {
+        gap: 0.95rem;
+        padding-right: 1.25rem;
+    }
+
+    .site-header {
+        grid-template-columns: minmax(0, 1fr) minmax(14rem, 24rem);
+        gap: 0.8rem;
+        padding: 1rem 1.5rem 0;
+    }
+
+    .site-header-copy {
+        max-width: 22rem;
+        font-size: 0.84rem;
+    }
+
+    .site-title {
+        font-size: clamp(1.55rem, 3.2vw, 2.15rem);
+    }
+
+    .portfolio-page,
+    .home-page,
+    .resume-page,
+    .auth-page,
+    .admin-page,
+    .contact-page {
+        gap: 1rem;
+        padding: 1.5rem;
+    }
+
+    .hero-panel {
+        padding: 1.25rem;
+    }
+
+    .hero-panel h1 {
+        font-size: clamp(1.9rem, 3vw, 2.5rem);
+        line-height: 1.14;
+        max-width: 18ch;
+    }
+
+    .hero-description {
+        max-width: 42rem;
+        font-size: 0.9rem;
+        line-height: 1.45;
+    }
+
+    .hero-stats {
+        gap: 0.6rem;
+    }
+
+    .stat-card {
+        padding: 0.72rem 0.82rem;
+    }
+
+    .sticky-filters {
+        top: 0.55rem;
+        gap: 0.65rem;
+        padding: 0.8rem 0.85rem;
+        border-radius: 1.2rem;
+    }
+
+    .filter-heading {
+        gap: 0.65rem;
+    }
+
+    .filter-heading-copy h2 {
+        font-size: 1.02rem;
+    }
+
+    .filter-summary {
+        gap: 0.55rem;
+    }
+
+    .filter-stat {
+        padding: 0.62rem 0.75rem;
+    }
+
+    .search-panel,
+    .search-panel-label,
+    .filter-actions,
+    .skill-filter-panel {
+        gap: 0.4rem;
+    }
+
+    .search-panel input,
+    .clear-button {
+        min-height: 2.65rem;
+    }
+
+    .toolbar-helper {
+        display: none;
+    }
+
+    .skill-filter-panel {
+        padding: 0.72rem 0.78rem;
+    }
+
+    .skill-filter-header {
+        gap: 0.45rem;
+    }
+
+    .active-filter-pill {
+        padding: 0.28rem 0.58rem;
+    }
+
+    .skill-strip,
+    .tag-group {
+        gap: 0.45rem;
+    }
+
+    .skill-chip {
+        padding: 0.5rem 0.72rem;
+        font-size: 0.84rem;
+    }
+
+    .project-list {
+        gap: 0.85rem;
+    }
+}
+
 @media (max-width: 900px) {
     .site-shell {
         grid-template-columns: 1fr;

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1042,8 +1042,8 @@
     top: 0.75rem;
     z-index: 10;
     display: grid;
-    gap: 0.85rem;
-    padding: 1rem;
+    gap: 1rem;
+    padding: 1.1rem;
     border: 1px solid rgba(111, 137, 171, 0.18);
     border-radius: 1.5rem;
     background:
@@ -1188,6 +1188,10 @@
 
 .detail-heading,
 .hero-stats,
+.filter-heading,
+.filter-summary,
+.filter-actions,
+.skill-filter-header,
 .toolbar,
 .carousel-shell,
 .project-card,
@@ -1296,14 +1300,112 @@
 }
 
 .toolbar {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1.2fr) minmax(16rem, 0.8fr);
     gap: 1rem;
-    align-items: end;
+    align-items: stretch;
 }
 
 .search-panel {
     display: grid;
-    gap: 0.55rem;
+    gap: 0.5rem;
+    align-content: start;
+}
+
+.search-panel-label {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.filter-heading {
+    grid-template-columns: minmax(0, 1.15fr) minmax(16rem, 0.85fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.filter-heading-copy,
+.filter-stat {
+    display: grid;
+}
+
+.filter-heading-copy {
+    gap: 0.65rem;
+}
+
+.filter-heading-copy .eyebrow {
+    margin-bottom: 0;
+}
+
+.filter-heading-copy h2 {
+    margin: 0;
+    color: #fffaf0;
+    font-size: clamp(1.15rem, 1.8vw, 1.45rem);
+    line-height: 1.2;
+}
+
+.filter-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.85rem;
+}
+
+.filter-stat {
+    gap: 0.35rem;
+    padding: 0.95rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1.15rem;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.03));
+}
+
+.filter-stat strong {
+    color: #f4f8fe;
+    font-size: 1rem;
+    line-height: 1.4;
+}
+
+.toolbar-helper {
+    margin: 0;
+    color: rgba(213, 224, 239, 0.68);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.filter-actions {
+    gap: 0.75rem;
+    align-content: start;
+}
+
+.skill-filter-panel {
+    display: grid;
+    gap: 0.85rem;
+    padding: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1.3rem;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+}
+
+.skill-filter-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: start;
+}
+
+.active-filter-pill {
+    margin: 0;
+    padding: 0.45rem 0.8rem;
+    border: 1px solid rgba(245, 183, 48, 0.3);
+    border-radius: 999px;
+    background: rgba(245, 183, 48, 0.14);
+    color: #fff0c0;
+    font-size: 0.84rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.active-filter-pill.muted {
+    border-color: rgba(111, 137, 171, 0.2);
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(213, 224, 239, 0.76);
 }
 
 .search-panel input {
@@ -2593,13 +2695,21 @@
         white-space: normal;
     }
 
+    .filter-heading,
+    .filter-summary,
     .toolbar,
+    .skill-filter-header,
     .featured-panel-heading,
     .milestone-heading,
     .auth-actions,
     .work-role-heading {
         grid-template-columns: 1fr;
         align-items: stretch;
+    }
+
+    .filter-stat,
+    .skill-filter-panel {
+        padding-inline: 0.9rem;
     }
 
     .work-role-list {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1322,6 +1322,17 @@
     align-items: center;
 }
 
+.filter-heading-side,
+.skill-filter-actions,
+.filter-workspace {
+    display: grid;
+}
+
+.filter-heading-side {
+    gap: 0.55rem;
+    align-items: start;
+}
+
 .filter-heading-copy,
 .filter-stat {
     display: grid;
@@ -1374,6 +1385,10 @@
     align-content: start;
 }
 
+.filter-workspace {
+    gap: 0.7rem;
+}
+
 .skill-filter-panel {
     display: grid;
     gap: 0.7rem;
@@ -1387,6 +1402,12 @@
 .skill-filter-header {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.55rem;
+    align-items: center;
+}
+
+.skill-filter-actions {
+    grid-auto-flow: column;
+    gap: 0.45rem;
     align-items: center;
 }
 
@@ -1406,6 +1427,48 @@
     border-color: rgba(111, 137, 171, 0.2);
     background: rgba(255, 255, 255, 0.06);
     color: rgba(213, 224, 239, 0.76);
+}
+
+.filter-toggle {
+    min-height: 2.45rem;
+    padding: 0.58rem 0.9rem;
+    border: 1px solid rgba(111, 137, 171, 0.2);
+    border-radius: 999px;
+    background: rgba(12, 27, 47, 0.92);
+    color: #dce7f5;
+    font-size: 0.84rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.filter-toggle:hover {
+    transform: translateY(-1px);
+}
+
+.filter-toggle:focus-visible {
+    outline: none;
+    border-color: rgba(245, 183, 48, 0.78);
+    box-shadow: 0 0 0 0.2rem rgba(245, 183, 48, 0.14);
+}
+
+.filter-collapsed-copy {
+    margin: 0;
+    color: rgba(213, 224, 239, 0.76);
+    font-size: 0.84rem;
+    line-height: 1.35;
+}
+
+.sticky-filters.collapsed {
+    gap: 0.6rem;
+}
+
+.sticky-filters.collapsed .filter-heading {
+    align-items: start;
+}
+
+.skill-filter-panel.collapsed {
+    gap: 0.5rem;
 }
 
 .search-panel input {
@@ -2657,6 +2720,10 @@
         gap: 0.65rem;
     }
 
+    .filter-heading-side {
+        gap: 0.45rem;
+    }
+
     .filter-heading-copy h2 {
         font-size: 1.02rem;
     }
@@ -2676,8 +2743,14 @@
         gap: 0.4rem;
     }
 
+    .filter-workspace,
+    .skill-filter-actions {
+        gap: 0.4rem;
+    }
+
     .search-panel input,
-    .clear-button {
+    .clear-button,
+    .filter-toggle {
         min-height: 2.65rem;
     }
 
@@ -2695,6 +2768,10 @@
 
     .active-filter-pill {
         padding: 0.28rem 0.58rem;
+    }
+
+    .filter-collapsed-copy {
+        font-size: 0.8rem;
     }
 
     .skill-strip,
@@ -2855,9 +2932,11 @@
     }
 
     .filter-heading,
+    .filter-heading-side,
     .filter-summary,
     .toolbar,
     .skill-filter-header,
+    .skill-filter-actions,
     .featured-panel-heading,
     .milestone-heading,
     .auth-actions,

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -2936,12 +2936,17 @@
     .filter-summary,
     .toolbar,
     .skill-filter-header,
-    .skill-filter-actions,
     .featured-panel-heading,
     .milestone-heading,
     .auth-actions,
     .work-role-heading {
         grid-template-columns: 1fr;
+        align-items: stretch;
+    }
+
+    .skill-filter-actions {
+        grid-template-columns: 1fr;
+        grid-auto-flow: row;
         align-items: stretch;
     }
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1029,7 +1029,7 @@
 
 .portfolio-page {
     display: grid;
-    gap: 1.5rem;
+    gap: 1.2rem;
     padding: 2rem;
 }
 
@@ -1042,8 +1042,8 @@
     top: 0.75rem;
     z-index: 10;
     display: grid;
-    gap: 1rem;
-    padding: 1.1rem;
+    gap: 0.8rem;
+    padding: 0.95rem 1rem;
     border: 1px solid rgba(111, 137, 171, 0.18);
     border-radius: 1.5rem;
     background:
@@ -1089,7 +1089,7 @@
 }
 
 .hero-panel {
-    padding: 2rem;
+    padding: 1.55rem;
 }
 
 .detail-hero {
@@ -1168,7 +1168,7 @@
 }
 
 .hero-copy {
-    gap: 1.75rem;
+    gap: 1.2rem;
 }
 
 .detail-copy {
@@ -1213,8 +1213,8 @@
 .detail-summary {
     max-width: 48rem;
     color: rgba(245, 241, 232, 0.9);
-    font-size: 1.02rem;
-    line-height: 1.7;
+    font-size: 0.96rem;
+    line-height: 1.55;
 }
 
 .home-intro .hero-description,
@@ -1231,14 +1231,14 @@
 
 .hero-stats {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
+    gap: 0.75rem;
 }
 
 .stat-card {
     display: grid;
-    gap: 0.3rem;
-    padding: 1rem;
-    border-radius: 1rem;
+    gap: 0.2rem;
+    padding: 0.8rem 0.9rem;
+    border-radius: 0.95rem;
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.12);
     backdrop-filter: blur(10px);
@@ -1295,13 +1295,13 @@
 }
 
 .stat-card strong {
-    font-size: clamp(1.8rem, 5vw, 2.6rem);
+    font-size: clamp(1.55rem, 4vw, 2.15rem);
     line-height: 1;
 }
 
 .toolbar {
-    grid-template-columns: minmax(0, 1.2fr) minmax(16rem, 0.8fr);
-    gap: 1rem;
+    grid-template-columns: minmax(0, 1.35fr) minmax(15rem, 0.65fr);
+    gap: 0.75rem;
     align-items: stretch;
 }
 
@@ -1318,8 +1318,8 @@
 
 .filter-heading {
     grid-template-columns: minmax(0, 1.15fr) minmax(16rem, 0.85fr);
-    gap: 1rem;
-    align-items: start;
+    gap: 0.75rem;
+    align-items: center;
 }
 
 .filter-heading-copy,
@@ -1328,7 +1328,7 @@
 }
 
 .filter-heading-copy {
-    gap: 0.65rem;
+    gap: 0.4rem;
 }
 
 .filter-heading-copy .eyebrow {
@@ -1338,66 +1338,66 @@
 .filter-heading-copy h2 {
     margin: 0;
     color: #fffaf0;
-    font-size: clamp(1.15rem, 1.8vw, 1.45rem);
-    line-height: 1.2;
+    font-size: clamp(1.02rem, 1.4vw, 1.2rem);
+    line-height: 1.15;
 }
 
 .filter-summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.85rem;
+    gap: 0.65rem;
 }
 
 .filter-stat {
     gap: 0.35rem;
-    padding: 0.95rem 1rem;
+    padding: 0.7rem 0.85rem;
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 1.15rem;
+    border-radius: 1rem;
     background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.03));
 }
 
 .filter-stat strong {
     color: #f4f8fe;
-    font-size: 1rem;
-    line-height: 1.4;
+    font-size: 0.92rem;
+    line-height: 1.25;
 }
 
 .toolbar-helper {
     margin: 0;
     color: rgba(213, 224, 239, 0.68);
-    font-size: 0.9rem;
-    line-height: 1.5;
+    font-size: 0.82rem;
+    line-height: 1.35;
 }
 
 .filter-actions {
-    gap: 0.75rem;
+    gap: 0.45rem;
     align-content: start;
 }
 
 .skill-filter-panel {
     display: grid;
-    gap: 0.85rem;
-    padding: 1rem;
+    gap: 0.7rem;
+    padding: 0.8rem 0.9rem;
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 1.3rem;
+    border-radius: 1.1rem;
     background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
 }
 
 .skill-filter-header {
     grid-template-columns: minmax(0, 1fr) auto;
-    gap: 0.75rem;
-    align-items: start;
+    gap: 0.55rem;
+    align-items: center;
 }
 
 .active-filter-pill {
     margin: 0;
-    padding: 0.45rem 0.8rem;
+    padding: 0.35rem 0.65rem;
     border: 1px solid rgba(245, 183, 48, 0.3);
     border-radius: 999px;
     background: rgba(245, 183, 48, 0.14);
     color: #fff0c0;
-    font-size: 0.84rem;
+    font-size: 0.78rem;
     font-weight: 700;
     letter-spacing: 0.04em;
 }
@@ -1410,8 +1410,8 @@
 
 .search-panel input {
     width: 100%;
-    min-height: 3.2rem;
-    padding: 0.85rem 1rem;
+    min-height: 2.85rem;
+    padding: 0.72rem 0.95rem;
     border: 1px solid rgba(111, 137, 171, 0.18);
     border-radius: 999px;
     background: rgba(8, 17, 31, 0.72);
@@ -1441,12 +1441,13 @@
 }
 
 .clear-button {
-    min-height: 3.2rem;
-    padding: 0.8rem 1.15rem;
+    min-height: 2.85rem;
+    padding: 0.68rem 0.95rem;
     border: 1px solid rgba(111, 137, 171, 0.18);
     border-radius: 999px;
     background: rgba(16, 34, 58, 0.82);
     color: #f4f8fe;
+    font-size: 0.92rem;
     font-weight: 700;
     cursor: pointer;
 }
@@ -1472,17 +1473,17 @@
 .inline-links,
 .gallery-rail {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.55rem;
     flex-wrap: wrap;
 }
 
 .skill-chip {
-    padding: 0.72rem 1rem;
+    padding: 0.56rem 0.82rem;
     border: 1px solid rgba(111, 137, 171, 0.18);
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.08);
     color: rgba(236, 243, 252, 0.92);
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     cursor: pointer;
 }
 
@@ -2658,7 +2659,7 @@
 
     .sticky-filters {
         top: 0;
-        padding: 0.85rem;
+        padding: 0.8rem;
         border-radius: 1rem;
     }
 
@@ -2669,7 +2670,7 @@
     .contact-hero,
     .resume-hero,
     .contact-panel {
-        padding: 1.35rem;
+        padding: 1.15rem;
     }
 
     .hero-stats {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -598,17 +598,22 @@ describe('App', () => {
         render(<App />);
 
         expect(await screen.findByRole('heading', { name: 'Portfolio Refresh' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Search the archive, then stack skills to narrow the field.' })).toBeInTheDocument();
+        expect(screen.getAllByText('Showing 1 published project').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('No active filters').length).toBeGreaterThan(0);
 
         fireEvent.change(screen.getByRole('searchbox', { name: 'Search projects' }), {
             target: { value: 'React' }
         });
 
         expect(await screen.findByRole('heading', { name: 'React Search Result' })).toBeInTheDocument();
+        expect(screen.getAllByText('1 active filter').length).toBeGreaterThan(0);
         expect(window.location.search).toBe('?search=React');
 
         fireEvent.click(screen.getByRole('button', { name: 'Testing' }));
 
         expect(await screen.findByRole('heading', { name: 'Testing Skill Result' })).toBeInTheDocument();
+        expect(screen.getAllByText('2 active filters').length).toBeGreaterThan(0);
         expect(screen.getByRole('button', { name: 'Testing' })).toHaveAttribute('aria-pressed', 'true');
         expect(window.location.search).toBe('?search=React&skills=Testing');
     });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -616,6 +616,24 @@ describe('App', () => {
         expect(screen.getAllByText('2 active filters').length).toBeGreaterThan(0);
         expect(screen.getByRole('button', { name: 'Testing' })).toHaveAttribute('aria-pressed', 'true');
         expect(window.location.search).toBe('?search=React&skills=Testing');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Hide skills' }));
+
+        expect(screen.queryByRole('button', { name: 'Testing' })).not.toBeInTheDocument();
+        expect(screen.getByText('1 selected skill')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show skills' }));
+
+        expect(screen.getByRole('button', { name: 'Testing' })).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Collapse filters' }));
+
+        expect(screen.queryByRole('searchbox', { name: 'Search projects' })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Expand filters' })).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Expand filters' }));
+
+        expect(screen.getByRole('searchbox', { name: 'Search projects' })).toBeInTheDocument();
     });
 
     it('renders the detail view and preserves list filters in the back link', async () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectListPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectListPage.tsx
@@ -44,6 +44,12 @@ export function ProjectListPage({
     const showingCount = projects.length;
     const activeFilterCount = selectedSkills.length + (searchInput.trim().length > 0 ? 1 : 0);
     const isEmpty = !isLoading && !error && showingCount === 0;
+    const resultSummary = showingCount === totalCount
+        ? `Showing ${showingCount} ${getProjectLabel(showingCount)}`
+        : `Showing ${showingCount} of ${totalCount} ${getProjectLabel(totalCount)}`;
+    const activeFilterSummary = activeFilterCount === 0
+        ? 'No active filters'
+        : `${activeFilterCount} active ${activeFilterCount === 1 ? 'filter' : 'filters'}`;
 
     return (
         <main className="portfolio-page">
@@ -76,49 +82,86 @@ export function ProjectListPage({
             </section>
 
             <section className="sticky-filters">
-                <div className="toolbar" aria-label="Project filters">
-                    <label className="search-panel" htmlFor="project-search">
-                        <span className="search-label">Search projects</span>
-                        <input
-                            id="project-search"
-                            name="project-search"
-                            type="search"
-                            value={searchInput}
-                            onChange={event => handleSearchChange(event.target.value)}
-                            placeholder="Search by title, summary, technology, or skill"
-                        />
-                    </label>
+                <div className="filter-heading">
+                    <div className="filter-heading-copy">
+                        <p className="eyebrow">Refine The Results</p>
+                        <h2>Search the archive, then stack skills to narrow the field.</h2>
+                    </div>
 
-                    <button
-                        className="clear-button"
-                        type="button"
-                        onClick={clearFilters}
-                        disabled={searchInput.length === 0 && selectedSkills.length === 0}>
-                        Reset filters
-                    </button>
+                    <div className="filter-summary" aria-label="Filter summary">
+                        <div className="filter-stat">
+                            <span className="search-label">Results</span>
+                            <strong>{resultSummary}</strong>
+                        </div>
+                        <div className="filter-stat">
+                            <span className="search-label">Selection</span>
+                            <strong>{activeFilterSummary}</strong>
+                        </div>
+                    </div>
                 </div>
 
-                <section className="skill-strip" aria-label="Skill filters">
-                    {availableSkills.length === 0 && isInitialLoad ? (
-                        <p className="helper-copy">Loading skill filters...</p>
-                    ) : availableSkills.length === 0 ? (
-                        <p className="helper-copy">Skill filters will appear once published projects are available.</p>
-                    ) : (
-                        availableSkills.map(skill => {
-                            const isSelected = selectedSkills.includes(skill);
+                <div className="toolbar" aria-label="Project filters">
+                    <div className="search-panel">
+                        <label className="search-panel-label" htmlFor="project-search">
+                            <span className="search-label">Search projects</span>
+                            <input
+                                id="project-search"
+                                name="project-search"
+                                type="search"
+                                value={searchInput}
+                                onChange={event => handleSearchChange(event.target.value)}
+                                aria-describedby="project-search-helper"
+                                placeholder="Search by title, summary, technology, or skill"
+                            />
+                        </label>
+                        <p id="project-search-helper" className="toolbar-helper">
+                            Search titles, summaries, technologies, or skill tags.
+                        </p>
+                    </div>
 
-                            return (
-                                <button
-                                    key={skill}
-                                    className={`skill-chip${isSelected ? ' selected' : ''}`}
-                                    type="button"
-                                    onClick={() => toggleSkill(skill)}
-                                    aria-pressed={isSelected}>
-                                    {skill}
-                                </button>
-                            );
-                        })
-                    )}
+                    <div className="filter-actions">
+                        <button
+                            className="clear-button"
+                            type="button"
+                            onClick={clearFilters}
+                            disabled={searchInput.length === 0 && selectedSkills.length === 0}>
+                            Reset filters
+                        </button>
+                        <p className="toolbar-helper">The current filters stay in the URL and carry into detail views.</p>
+                    </div>
+                </div>
+
+                <section className="skill-filter-panel" aria-label="Skill filters">
+                    <div className="skill-filter-header">
+                        <div>
+                            <span className="search-label">Skill filters</span>
+                            <p className="toolbar-helper">Layer skills onto the current search without losing context.</p>
+                        </div>
+                        <p className={`active-filter-pill${activeFilterCount === 0 ? ' muted' : ''}`}>{activeFilterSummary}</p>
+                    </div>
+
+                    <div className="skill-strip">
+                        {availableSkills.length === 0 && isInitialLoad ? (
+                            <p className="helper-copy">Loading skill filters...</p>
+                        ) : availableSkills.length === 0 ? (
+                            <p className="helper-copy">Skill filters will appear once published projects are available.</p>
+                        ) : (
+                            availableSkills.map(skill => {
+                                const isSelected = selectedSkills.includes(skill);
+
+                                return (
+                                    <button
+                                        key={skill}
+                                        className={`skill-chip${isSelected ? ' selected' : ''}`}
+                                        type="button"
+                                        onClick={() => toggleSkill(skill)}
+                                        aria-pressed={isSelected}>
+                                        {skill}
+                                    </button>
+                                );
+                            })
+                        )}
+                    </div>
                 </section>
             </section>
 
@@ -145,6 +188,10 @@ export function ProjectListPage({
             {!hasMore && projects.length > 0 ? <p className="helper-copy">You&apos;ve reached the end of the published project list.</p> : null}
         </main>
     );
+}
+
+function getProjectLabel(count: number) {
+    return `${count === 1 ? 'published project' : 'published projects'}`;
 }
 
 interface ProjectCardProps {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectListPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectListPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import projectImageUnavailable from '../../assets/Placeholders/Project-Image-Unavailable.png';
 import type { NavigateFn } from '../../app/navigation';
 import type { ProjectSummary } from '../../app/types';
@@ -21,6 +21,8 @@ export function ProjectListPage({
     filters,
     onNavigate
 }: ProjectListPageProps) {
+    const [isFilterTrayCollapsed, setIsFilterTrayCollapsed] = useState(false);
+    const [isSkillFiltersCollapsed, setIsSkillFiltersCollapsed] = useState(false);
     const {
         searchInput,
         selectedSkills,
@@ -50,6 +52,9 @@ export function ProjectListPage({
     const activeFilterSummary = activeFilterCount === 0
         ? 'No active filters'
         : `${activeFilterCount} active ${activeFilterCount === 1 ? 'filter' : 'filters'}`;
+    const collapsedSkillSummary = selectedSkills.length > 0
+        ? `${selectedSkills.length} selected ${selectedSkills.length === 1 ? 'skill' : 'skills'}`
+        : `${availableSkills.length} available ${availableSkills.length === 1 ? 'skill' : 'skills'}`;
 
     return (
         <main className="portfolio-page">
@@ -81,88 +86,117 @@ export function ProjectListPage({
                 </div>
             </section>
 
-            <section className="sticky-filters">
+            <section className={`sticky-filters${isFilterTrayCollapsed ? ' collapsed' : ''}`}>
                 <div className="filter-heading">
                     <div className="filter-heading-copy">
                         <p className="eyebrow">Refine The Results</p>
                         <h2>Search the archive, then stack skills to narrow the field.</h2>
                     </div>
 
-                    <div className="filter-summary" aria-label="Filter summary">
-                        <div className="filter-stat">
-                            <span className="search-label">Results</span>
-                            <strong>{resultSummary}</strong>
+                    <div className="filter-heading-side">
+                        <div className="filter-summary" aria-label="Filter summary">
+                            <div className="filter-stat">
+                                <span className="search-label">Results</span>
+                                <strong>{resultSummary}</strong>
+                            </div>
+                            <div className="filter-stat">
+                                <span className="search-label">Selection</span>
+                                <strong>{activeFilterSummary}</strong>
+                            </div>
                         </div>
-                        <div className="filter-stat">
-                            <span className="search-label">Selection</span>
-                            <strong>{activeFilterSummary}</strong>
-                        </div>
-                    </div>
-                </div>
 
-                <div className="toolbar" aria-label="Project filters">
-                    <div className="search-panel">
-                        <label className="search-panel-label" htmlFor="project-search">
-                            <span className="search-label">Search projects</span>
-                            <input
-                                id="project-search"
-                                name="project-search"
-                                type="search"
-                                value={searchInput}
-                                onChange={event => handleSearchChange(event.target.value)}
-                                aria-describedby="project-search-helper"
-                                placeholder="Search by title, summary, technology, or skill"
-                            />
-                        </label>
-                        <p id="project-search-helper" className="toolbar-helper">
-                            Search titles, summaries, technologies, or skill tags.
-                        </p>
-                    </div>
-
-                    <div className="filter-actions">
                         <button
-                            className="clear-button"
                             type="button"
-                            onClick={clearFilters}
-                            disabled={searchInput.length === 0 && selectedSkills.length === 0}>
-                            Reset filters
+                            className="filter-toggle"
+                            aria-expanded={!isFilterTrayCollapsed}
+                            aria-controls="project-filter-workspace"
+                            onClick={() => setIsFilterTrayCollapsed(current => !current)}>
+                            {isFilterTrayCollapsed ? 'Expand filters' : 'Collapse filters'}
                         </button>
-                        <p className="toolbar-helper">The current filters stay in the URL and carry into detail views.</p>
                     </div>
                 </div>
 
-                <section className="skill-filter-panel" aria-label="Skill filters">
-                    <div className="skill-filter-header">
-                        <div>
-                            <span className="search-label">Skill filters</span>
-                            <p className="toolbar-helper">Layer skills onto the current search without losing context.</p>
+                {!isFilterTrayCollapsed ? (
+                    <div id="project-filter-workspace" className="filter-workspace">
+                        <div className="toolbar" aria-label="Project filters">
+                            <div className="search-panel">
+                                <label className="search-panel-label" htmlFor="project-search">
+                                    <span className="search-label">Search projects</span>
+                                    <input
+                                        id="project-search"
+                                        name="project-search"
+                                        type="search"
+                                        value={searchInput}
+                                        onChange={event => handleSearchChange(event.target.value)}
+                                        aria-describedby="project-search-helper"
+                                        placeholder="Search by title, summary, technology, or skill"
+                                    />
+                                </label>
+                                <p id="project-search-helper" className="toolbar-helper">
+                                    Search titles, summaries, technologies, or skill tags.
+                                </p>
+                            </div>
+
+                            <div className="filter-actions">
+                                <button
+                                    className="clear-button"
+                                    type="button"
+                                    onClick={clearFilters}
+                                    disabled={searchInput.length === 0 && selectedSkills.length === 0}>
+                                    Reset filters
+                                </button>
+                                <p className="toolbar-helper">The current filters stay in the URL and carry into detail views.</p>
+                            </div>
                         </div>
-                        <p className={`active-filter-pill${activeFilterCount === 0 ? ' muted' : ''}`}>{activeFilterSummary}</p>
-                    </div>
 
-                    <div className="skill-strip">
-                        {availableSkills.length === 0 && isInitialLoad ? (
-                            <p className="helper-copy">Loading skill filters...</p>
-                        ) : availableSkills.length === 0 ? (
-                            <p className="helper-copy">Skill filters will appear once published projects are available.</p>
-                        ) : (
-                            availableSkills.map(skill => {
-                                const isSelected = selectedSkills.includes(skill);
-
-                                return (
+                        <section className={`skill-filter-panel${isSkillFiltersCollapsed ? ' collapsed' : ''}`} aria-label="Skill filters">
+                            <div className="skill-filter-header">
+                                <div>
+                                    <span className="search-label">Skill filters</span>
+                                    <p className="toolbar-helper">Layer skills onto the current search without losing context.</p>
+                                </div>
+                                <div className="skill-filter-actions">
+                                    <p className={`active-filter-pill${activeFilterCount === 0 ? ' muted' : ''}`}>{activeFilterSummary}</p>
                                     <button
-                                        key={skill}
-                                        className={`skill-chip${isSelected ? ' selected' : ''}`}
                                         type="button"
-                                        onClick={() => toggleSkill(skill)}
-                                        aria-pressed={isSelected}>
-                                        {skill}
+                                        className="filter-toggle"
+                                        aria-expanded={!isSkillFiltersCollapsed}
+                                        aria-controls="project-skill-filter-list"
+                                        onClick={() => setIsSkillFiltersCollapsed(current => !current)}>
+                                        {isSkillFiltersCollapsed ? 'Show skills' : 'Hide skills'}
                                     </button>
-                                );
-                            })
-                        )}
+                                </div>
+                            </div>
+
+                            {!isSkillFiltersCollapsed ? (
+                                <div id="project-skill-filter-list" className="skill-strip">
+                                    {availableSkills.length === 0 && isInitialLoad ? (
+                                        <p className="helper-copy">Loading skill filters...</p>
+                                    ) : availableSkills.length === 0 ? (
+                                        <p className="helper-copy">Skill filters will appear once published projects are available.</p>
+                                    ) : (
+                                        availableSkills.map(skill => {
+                                            const isSelected = selectedSkills.includes(skill);
+
+                                            return (
+                                                <button
+                                                    key={skill}
+                                                    className={`skill-chip${isSelected ? ' selected' : ''}`}
+                                                    type="button"
+                                                    onClick={() => toggleSkill(skill)}
+                                                    aria-pressed={isSelected}>
+                                                    {skill}
+                                                </button>
+                                            );
+                                        })
+                                    )}
+                                </div>
+                            ) : (
+                                <p className="filter-collapsed-copy">{collapsedSkillSummary}</p>
+                            )}
+                        </section>
                     </div>
-                </section>
+                ) : null}
             </section>
 
             {error ? <p className="status-banner error">{error}</p> : null}

--- a/TODO.MD
+++ b/TODO.MD
@@ -7,6 +7,7 @@
 - Ensure uploaded project images match the main display ratio of `2047:768`, and if an upload does not match, provide a user-controlled crop/position workflow before publishing.
 - Optimize the placeholder image assets for production so the fallback visuals keep their styling without carrying unnecessary bundle weight.
 - Evaluate and refine the public site's long-term color palette in a separate issue from dark-theme consistency work.
+- Work with the user on theme and `site.css` refinements so the site is more usable, compact, and visually polished across device types. Tracked in issue #128.
 - Refactor `projectportfolio2026.client/src/App.tsx` into maintainable frontend modules before additional UI work keeps expanding the current monolith. Tracked in issue #45.
 - Design password reset and account recovery for local accounts without requiring email or SMS delivery. Tracked in issue #59.
 - Consider showing the logged-in user's display name in the admin navigation or header once the MVP admin shell is stable.


### PR DESCRIPTION
## Summary
Addresses #125 by refining the public projects filter workspace so the search, reset, and skill controls feel integrated with the site shell.

## Changes
- add a structured filter-workspace header with live result and active-filter summaries
- regroup the search field, helper copy, and reset action into a clearer two-column toolbar
- wrap skill chips in a dedicated filter panel with contextual copy and active-state feedback
- cover the new filter summary copy in the existing App interaction test

## Verification
- npm test
- npm run lint
- npm run build
- launched the local API + Vite app and opened `/projects` in Microsoft Edge