### PR TITLE
test: cover blank uploaded resume filename fallback

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeParserServiceTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeParserServiceTests.cs
@@ -115,6 +115,26 @@ public sealed class ResumeParserServiceTests
     }
 
     [Test]
+    public async Task ParseAsync_UsesParserProvidedSourceFileNameWhenUploadedFileNameIsBlank()
+    {
+        var parser = new StubResumeDocumentParser
+        {
+            Result = new ResumeDocument
+            {
+                SourceFileName = "parsed-resume.pdf",
+                ParserName = "StubParser"
+            }
+        };
+        var service = new ResumeParserService(parser);
+
+        using var stream = new MemoryStream([1, 2, 3]);
+
+        var result = await service.ParseAsync(stream, string.Empty);
+
+        Assert.That(result.SourceFileName, Is.EqualTo("parsed-resume.pdf"));
+    }
+
+    [Test]
     public async Task ParseAsync_ReturnsNullPersonWhenParserDoesNotProvideHeader()
     {
         var parser = new StubResumeDocumentParser


### PR DESCRIPTION
## Summary
- add a focused regression test for the blank uploaded filename branch in ResumeParserService
- verify the service falls back to the parser-provided source filename when no uploaded filename is available

## Verification
- dotnet test ProjectPortfolio2026\\ProjectPortfolio2026.Server.Tests\\ProjectPortfolio2026.Server.Tests.csproj --filter ResumeParserServiceTests -c Release
