### PR TITLE
#131 Add project filter reset coverage

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -634,6 +634,37 @@ describe('App', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Expand filters' }));
 
         expect(screen.getByRole('searchbox', { name: 'Search projects' })).toBeInTheDocument();
+
+        queueFetchJson(/^\/api\/projects\?/, {
+            requestId: 'request-1',
+            items: [
+                {
+                    id: 42,
+                    title: 'Portfolio Refresh',
+                    startDate: '2025-01-01',
+                    endDate: null,
+                    primaryImageUrl: null,
+                    shortDescription: 'Rebuilt the public portfolio experience.',
+                    isFeatured: true,
+                    skills: ['React'],
+                    technologies: ['TypeScript']
+                }
+            ],
+            page: 1,
+            pageSize: 6,
+            totalCount: 1,
+            hasMore: false,
+            availableSkills: ['React', 'Testing']
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
+
+        expect(await screen.findByRole('heading', { name: 'Portfolio Refresh' })).toBeInTheDocument();
+        expect(screen.getByRole('searchbox', { name: 'Search projects' })).toHaveValue('');
+        expect(screen.getByRole('button', { name: 'Testing' })).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getAllByText('No active filters').length).toBeGreaterThan(0);
+        expect(screen.getByRole('button', { name: 'Reset filters' })).toBeDisabled();
+        expect(window.location.search).toBe('');
     });
 
     it('renders the detail view and preserves list filters in the back link', async () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -635,7 +635,30 @@ describe('App', () => {
 
         expect(screen.getByRole('searchbox', { name: 'Search projects' })).toBeInTheDocument();
 
-        queueFetchJson(/^\/api\/projects\?/, {
+        const resetRequestPath = '/api/projects?page=1&pageSize=6&requestId=request-1';
+
+        queueFetchJson(resetRequestPath, {
+            requestId: 'request-1',
+            items: [
+                {
+                    id: 42,
+                    title: 'Portfolio Refresh',
+                    startDate: '2025-01-01',
+                    endDate: null,
+                    primaryImageUrl: null,
+                    shortDescription: 'Rebuilt the public portfolio experience.',
+                    isFeatured: true,
+                    skills: ['React'],
+                    technologies: ['TypeScript']
+                }
+            ],
+            page: 1,
+            pageSize: 6,
+            totalCount: 1,
+            hasMore: false,
+            availableSkills: ['React', 'Testing']
+        });
+        queueFetchJson(resetRequestPath, {
             requestId: 'request-1',
             items: [
                 {


### PR DESCRIPTION
Addresses #131

## Changelog
- extend the project list interaction test through the reset-filters path
- verify reset clears the query string, disables the reset control, and removes the selected skill state

## Validation
- `npm test -- src/App.test.tsx`
