### PR TITLE
#124 Refine public project list card hierarchy and spacing

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1578,8 +1578,8 @@
 
 .project-list {
     display: grid;
-    gap: 1rem;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 29rem), 1fr));
+    gap: 1.1rem;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 31rem), 1fr));
 }
 
 .project-year-spacer {
@@ -1773,9 +1773,9 @@
 
 .project-card {
     grid-template-columns: 1fr;
-    gap: 1rem;
+    gap: 1.1rem;
     align-items: start;
-    padding: 1.1rem;
+    padding: 1.25rem;
     border: 1px solid rgba(111, 137, 171, 0.16);
     border-radius: 1.5rem;
     background:
@@ -1889,7 +1889,7 @@
 }
 
 .card-copy {
-    gap: 1rem;
+    gap: 0.95rem;
     align-content: start;
     min-height: 100%;
 }
@@ -1897,6 +1897,19 @@
 .card-heading,
 .detail-meta,
 .detail-nav {
+    gap: 0.45rem;
+}
+
+.project-card-metadata,
+.project-card-metadata-group {
+    display: grid;
+}
+
+.project-card-metadata {
+    gap: 0.8rem;
+}
+
+.project-card-metadata-group {
     gap: 0.45rem;
 }
 
@@ -1909,6 +1922,7 @@
 }
 
 .project-dates {
+    margin: 0;
     color: rgba(213, 224, 239, 0.68);
     font-size: 0.86rem;
     font-weight: 700;
@@ -1936,7 +1950,25 @@
 }
 
 .project-card h2 {
+    margin: 0;
     color: #f4f8fe;
+    font-size: clamp(1.45rem, 2vw, 1.9rem);
+    line-height: 1.08;
+    max-width: 18ch;
+}
+
+.project-card .project-summary {
+    margin: 0;
+    line-height: 1.68;
+    max-width: 62ch;
+}
+
+.project-card .meta-label {
+    color: rgba(245, 241, 232, 0.66);
+}
+
+.project-card .tag-group {
+    gap: 0.45rem;
 }
 
 .carousel-copy h3 {
@@ -2072,6 +2104,19 @@
 
 .project-card .card-links {
     margin-top: auto;
+}
+
+@media (min-width: 1200px) {
+    .project-card {
+        grid-template-columns: minmax(15rem, 18rem) minmax(0, 1fr);
+        align-items: stretch;
+    }
+
+    .project-card .image-shell {
+        aspect-ratio: auto;
+        height: 100%;
+        min-height: 100%;
+    }
 }
 
 .detail-links a {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 import {
@@ -265,6 +265,14 @@ describe('App', () => {
         expect(screen.getByRole('button', { name: 'React' })).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByLabelText('Projects ending in Present')).toBeInTheDocument();
         expect(screen.getByLabelText('Projects ending in 2024')).toBeInTheDocument();
+
+        const featuredProjectCard = screen.getByRole('heading', { name: 'Portfolio Refresh' }).closest('article');
+        expect(featuredProjectCard).not.toBeNull();
+        expect(within(featuredProjectCard as HTMLElement).getByText('Skills')).toBeInTheDocument();
+        expect(within(featuredProjectCard as HTMLElement).getByText('Technology Stack')).toBeInTheDocument();
+        expect(within(featuredProjectCard as HTMLElement).getByLabelText('Portfolio Refresh skills')).toHaveTextContent('React');
+        expect(within(featuredProjectCard as HTMLElement).getByLabelText('Portfolio Refresh technologies')).toHaveTextContent('TypeScript');
+
         expect(fetchMock).toHaveBeenCalledWith('/api/projects?page=1&pageSize=6&requestId=request-1', expect.any(Object));
     });
 

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectListPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectListPage.tsx
@@ -278,17 +278,31 @@ function ProjectCard({
 
                     <p className="project-summary">{project.shortDescription}</p>
 
-                    <div className="tag-group" aria-label={`${project.title} skills`}>
-                        {project.skills.map(skill => (
-                            <span key={skill} className="tag skill">{skill}</span>
-                        ))}
-                    </div>
+                    {project.skills.length > 0 || project.technologies.length > 0 ? (
+                        <div className="project-card-metadata">
+                            {project.skills.length > 0 ? (
+                                <section className="project-card-metadata-group">
+                                    <span className="meta-label">Skills</span>
+                                    <div className="tag-group" aria-label={`${project.title} skills`}>
+                                        {project.skills.map(skill => (
+                                            <span key={skill} className="tag skill">{skill}</span>
+                                        ))}
+                                    </div>
+                                </section>
+                            ) : null}
 
-                    <div className="tag-group secondary" aria-label={`${project.title} technologies`}>
-                        {project.technologies.map(technology => (
-                            <span key={technology} className="tag technology">{technology}</span>
-                        ))}
-                    </div>
+                            {project.technologies.length > 0 ? (
+                                <section className="project-card-metadata-group">
+                                    <span className="meta-label">Technology Stack</span>
+                                    <div className="tag-group secondary" aria-label={`${project.title} technologies`}>
+                                        {project.technologies.map(technology => (
+                                            <span key={technology} className="tag technology">{technology}</span>
+                                        ))}
+                                    </div>
+                                </section>
+                            ) : null}
+                        </div>
+                    ) : null}
 
                     <div className="card-links">
                         <InternalLink


### PR DESCRIPTION
## Summary
Addresses #124.

## Changes
- tighten the project-list card spacing and content hierarchy
- add explicit Skills and Technology Stack groupings inside each card
- improve wider-card proportions on larger desktop widths without changing list filtering behavior
- add focused client coverage for the new card metadata sections

## Verification
- npm test
- npm run build
- dotnet build .\ProjectPortfolio2026.slnx -c Release
- dotnet test .\ProjectPortfolio2026.slnx -c Release --no-build