### PR TITLE
#126 Improve public project detail hierarchy and media balance

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.css
@@ -1127,6 +1127,18 @@
     display: grid;
 }
 
+.detail-heading-copy,
+.detail-panel-header,
+.detail-panel-heading,
+.detail-stack-panel,
+.detail-stack-header,
+.detail-summary-card,
+.detail-fact-grid,
+.detail-fact-card,
+.detail-visual-caption {
+    display: grid;
+}
+
 .home-intro-grid,
 .featured-panel-heading {
     gap: 1.25rem;
@@ -1188,6 +1200,7 @@
 
 .detail-heading,
 .hero-stats,
+.detail-heading-copy,
 .filter-heading,
 .filter-summary,
 .filter-actions,
@@ -1207,6 +1220,10 @@
 
 .detail-heading {
     gap: 0.75rem;
+}
+
+.detail-heading-copy {
+    gap: 0.45rem;
 }
 
 .hero-description,
@@ -1807,9 +1824,34 @@
 }
 
 .detail-visual {
+    display: grid;
+    align-items: end;
     aspect-ratio: 2047 / 768;
     min-height: 0;
     border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.detail-visual-caption {
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
+    gap: 0.35rem;
+    max-width: min(22rem, calc(100% - 2rem));
+    padding: 0.95rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 1rem;
+    background: rgba(7, 17, 31, 0.78);
+    box-shadow:
+        0 18px 44px rgba(2, 8, 18, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(10px);
+    z-index: 1;
+}
+
+.detail-visual-caption p:last-child {
+    margin: 0;
+    color: rgba(244, 248, 252, 0.88);
+    line-height: 1.65;
 }
 
 .image-shell img,
@@ -1966,6 +2008,58 @@
     margin-top: 0.15rem;
 }
 
+.detail-summary-card {
+    gap: 1rem;
+    padding: 1rem 1.05rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 1.2rem;
+    background:
+        linear-gradient(145deg, rgba(8, 18, 31, 0.36), rgba(23, 36, 54, 0.22));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.detail-fact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.85rem;
+}
+
+.detail-fact-card {
+    gap: 0.45rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1.1rem;
+    background: rgba(255, 255, 255, 0.06);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.detail-fact-card strong {
+    color: #fdf7ea;
+    font-size: 1rem;
+    line-height: 1.45;
+}
+
+.detail-fact-card.success {
+    border-color: rgba(99, 222, 255, 0.2);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(73, 124, 145, 0.14));
+}
+
+.detail-stack-panel {
+    gap: 0.9rem;
+    padding: 1rem 1.05rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1.2rem;
+    background: rgba(7, 17, 31, 0.22);
+}
+
+.detail-stack-header,
+.detail-panel-header {
+    gap: 0.45rem;
+}
+
+.detail-panel-heading {
+    gap: 0.4rem;
+}
+
 .tag {
     padding: 0.38rem 0.7rem;
     border-radius: 999px;
@@ -2080,6 +2174,12 @@
     border-color: rgba(255, 248, 236, 0.96);
 }
 
+.detail-links .secondary-link {
+    background: rgba(15, 19, 27, 0.42);
+    border-color: rgba(255, 255, 255, 0.16);
+    color: #fff7e8;
+}
+
 .detail-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1rem;
@@ -2110,7 +2210,7 @@
 .detail-column-media {
     grid-column: 2;
     position: sticky;
-    top: 0;
+    top: 0.75rem;
     align-self: start;
 }
 
@@ -2835,6 +2935,10 @@
         position: static;
     }
 
+    .detail-fact-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
     .carousel-shell {
         min-height: 22rem;
         padding-inline: 3.75rem;
@@ -2953,6 +3057,16 @@
     .filter-stat,
     .skill-filter-panel {
         padding-inline: 0.9rem;
+    }
+
+    .detail-fact-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .detail-visual-caption {
+        position: static;
+        max-width: none;
+        margin: 0.85rem;
     }
 
     .work-role-list {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -728,6 +728,8 @@ describe('App', () => {
         expect(screen.getByRole('heading', { name: 'Screenshots' })).toBeInTheDocument();
         expect(screen.getByRole('heading', { name: 'Collaborators' })).toBeInTheDocument();
         expect(screen.getByRole('heading', { name: 'Milestones' })).toBeInTheDocument();
+        expect(screen.getByLabelText('Project overview facts')).toBeInTheDocument();
+        expect(screen.getByLabelText('Project stack')).toBeInTheDocument();
         expect(screen.getByRole('region', { name: 'Project screenshot carousel' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Show next screenshot' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Live Demo' })).toHaveAttribute('href', 'https://example.com/launch-control');
@@ -736,6 +738,9 @@ describe('App', () => {
         expect(screen.getByText('Planned')).toBeInTheDocument();
         expect(screen.getByText('Taylor Dev')).toBeInTheDocument();
         expect(screen.getByText('Designer | QA')).toBeInTheDocument();
+        expect(screen.getByText('Roles, skills, and technologies that shaped the delivery.')).toBeInTheDocument();
+        expect(screen.getByText('The screenshot gallery below expands on this project view.')).toBeInTheDocument();
+        expect(screen.getByText('The delivery story, implementation context, and outcome for this project.')).toBeInTheDocument();
         expect(screen.getByText('Overview dashboard')).toBeInTheDocument();
         expect(screen.getByText('Screenshot 1 of 2')).toBeInTheDocument();
         expect(screen.getAllByAltText('Launch Control screenshot 2')).toHaveLength(2);

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectDetailPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/projects/ProjectDetailPage.tsx
@@ -24,8 +24,36 @@ export function ProjectDetailPage({
     onNavigate
 }: ProjectDetailPageProps) {
     const { project, isLoading, error, isMissing } = useProjectDetail(projectId);
-
     const backPath = buildProjectsPath(listSearch);
+    const completedMilestoneCount = project?.milestones.filter(milestone => !!milestone.completedOn).length ?? 0;
+    const detailFacts = project
+        ? [
+            {
+                label: 'Delivery Window',
+                value: formatProjectDates(project.startDate, project.endDate),
+                tone: 'default' as const
+            },
+            {
+                label: 'Project Media',
+                value: `${project.screenshots.length} screenshot${project.screenshots.length === 1 ? '' : 's'}`,
+                tone: 'default' as const
+            },
+            {
+                label: 'Collaborators',
+                value: project.collaborators.length > 0
+                    ? `${project.collaborators.length} teammate${project.collaborators.length === 1 ? '' : 's'}`
+                    : 'Solo build',
+                tone: 'default' as const
+            },
+            {
+                label: 'Milestones',
+                value: project.milestones.length > 0
+                    ? `${completedMilestoneCount}/${project.milestones.length} completed`
+                    : 'No milestones listed',
+                tone: completedMilestoneCount > 0 ? 'success' as const : 'default' as const
+            }
+        ]
+        : [];
 
     return (
         <main className="portfolio-page detail-page">
@@ -50,40 +78,60 @@ export function ProjectDetailPage({
                             <div className="detail-copy">
                                 <p className="eyebrow">Project Detail</p>
                                 <div className="detail-heading">
-                                    <div>
+                                    <div className="detail-heading-copy">
                                         <p className="project-dates">{formatProjectDates(project.startDate, project.endDate)}</p>
                                         <h1>{project.title}</h1>
                                     </div>
                                     {project.isFeatured ? <span className="featured-pill detail-featured-pill">Featured</span> : null}
                                 </div>
 
-                                <p className="detail-summary">{project.shortDescription}</p>
+                                <div className="detail-summary-card">
+                                    <p className="detail-summary">{project.shortDescription}</p>
 
-                                {project.developerRoles.length > 0 ? (
-                                    <MetadataGroup label="Roles" items={project.developerRoles} tone="technology" />
-                                ) : null}
+                                    {(project.demoUrl || project.gitHubUrl) ? (
+                                        <div className="card-links detail-links">
+                                            {project.demoUrl ? (
+                                                <a className="primary-link" href={project.demoUrl} target="_blank" rel="noreferrer">
+                                                    Live Demo
+                                                </a>
+                                            ) : null}
+                                            {project.gitHubUrl ? (
+                                                <a className="secondary-link" href={project.gitHubUrl} target="_blank" rel="noreferrer">
+                                                    Source
+                                                </a>
+                                            ) : null}
+                                        </div>
+                                    ) : null}
+                                </div>
 
-                                {project.skills.length > 0 ? (
-                                    <MetadataGroup label="Skills" items={project.skills} tone="skill" />
-                                ) : null}
+                                <div className="detail-fact-grid" aria-label="Project overview facts">
+                                    {detailFacts.map(fact => (
+                                        <article key={fact.label} className={`detail-fact-card${fact.tone === 'success' ? ' success' : ''}`}>
+                                            <span className="meta-label">{fact.label}</span>
+                                            <strong>{fact.value}</strong>
+                                        </article>
+                                    ))}
+                                </div>
 
-                                {project.technologies.length > 0 ? (
-                                    <MetadataGroup label="Technologies" items={project.technologies} tone="technology" />
-                                ) : null}
+                                {(project.developerRoles.length > 0 || project.skills.length > 0 || project.technologies.length > 0) ? (
+                                    <section className="detail-stack-panel" aria-label="Project stack">
+                                        <div className="detail-stack-header">
+                                            <p className="eyebrow">Project Stack</p>
+                                            <p className="secondary-copy">Roles, skills, and technologies that shaped the delivery.</p>
+                                        </div>
 
-                                {(project.demoUrl || project.gitHubUrl) ? (
-                                    <div className="card-links detail-links">
-                                        {project.demoUrl ? (
-                                            <a href={project.demoUrl} target="_blank" rel="noreferrer">
-                                                Live Demo
-                                            </a>
+                                        {project.developerRoles.length > 0 ? (
+                                            <MetadataGroup label="Roles" items={project.developerRoles} tone="technology" />
                                         ) : null}
-                                        {project.gitHubUrl ? (
-                                            <a href={project.gitHubUrl} target="_blank" rel="noreferrer">
-                                                Source
-                                            </a>
+
+                                        {project.skills.length > 0 ? (
+                                            <MetadataGroup label="Skills" items={project.skills} tone="skill" />
                                         ) : null}
-                                    </div>
+
+                                        {project.technologies.length > 0 ? (
+                                            <MetadataGroup label="Technologies" items={project.technologies} tone="technology" />
+                                        ) : null}
+                                    </section>
                                 ) : null}
                             </div>
 
@@ -95,6 +143,10 @@ export function ProjectDetailPage({
                                     fallbackSrc={projectImageUnavailable}
                                     className="detail-media"
                                 />
+                                <div className="detail-visual-caption">
+                                    <p className="eyebrow">Primary Preview</p>
+                                    <p>{project.screenshots.length > 0 ? 'The screenshot gallery below expands on this project view.' : 'This project currently ships without an additional screenshot gallery.'}</p>
+                                </div>
                             </div>
                         </section>
 
@@ -102,7 +154,11 @@ export function ProjectDetailPage({
                             <div className="detail-column detail-column-main">
                                 {project.longDescriptionMarkdown.trim().length > 0 ? (
                                     <section className="detail-panel">
-                                        <h2>Overview</h2>
+                                        <DetailPanelHeader
+                                            eyebrow="Narrative"
+                                            title="Overview"
+                                            description="The delivery story, implementation context, and outcome for this project."
+                                        />
                                         <div className="detail-markdown">
                                             {renderMarkdownParagraphs(project.longDescriptionMarkdown)}
                                         </div>
@@ -111,7 +167,11 @@ export function ProjectDetailPage({
 
                                 {project.collaborators.length > 0 ? (
                                     <section className="detail-panel">
-                                        <h2>Collaborators</h2>
+                                        <DetailPanelHeader
+                                            eyebrow="Team"
+                                            title="Collaborators"
+                                            description="People who contributed alongside the primary build effort."
+                                        />
                                         <div className="stack-list">
                                             {project.collaborators.map(collaborator => (
                                                 <article key={collaborator.name} className="stack-card collaborator-card">
@@ -154,7 +214,11 @@ export function ProjectDetailPage({
 
                                 {project.milestones.length > 0 ? (
                                     <section className="detail-panel">
-                                        <h2>Milestones</h2>
+                                        <DetailPanelHeader
+                                            eyebrow="Delivery"
+                                            title="Milestones"
+                                            description="Planned and completed checkpoints that shaped the release."
+                                        />
                                         <div className="stack-list">
                                             {project.milestones.map(milestone => (
                                                 <article key={`${milestone.title}-${milestone.targetDate}`} className="stack-card">
@@ -181,7 +245,11 @@ export function ProjectDetailPage({
                             <div className="detail-column detail-column-media">
                                 {project.screenshots.length > 0 ? (
                                     <section className="detail-panel">
-                                        <h2>Screenshots</h2>
+                                        <DetailPanelHeader
+                                            eyebrow="Project Media"
+                                            title="Screenshots"
+                                            description="Select a frame to inspect the interface in more detail."
+                                        />
                                         <ScreenshotCarousel
                                             projectTitle={project.title}
                                             screenshots={project.screenshots}
@@ -194,6 +262,28 @@ export function ProjectDetailPage({
                 ) : null}
             </section>
         </main>
+    );
+}
+
+interface DetailPanelHeaderProps {
+    eyebrow: string;
+    title: string;
+    description: string;
+}
+
+function DetailPanelHeader({
+    eyebrow,
+    title,
+    description
+}: DetailPanelHeaderProps) {
+    return (
+        <header className="detail-panel-header">
+            <p className="eyebrow">{eyebrow}</p>
+            <div className="detail-panel-heading">
+                <h2>{title}</h2>
+                <p className="secondary-copy">{description}</p>
+            </div>
+        </header>
     );
 }
 


### PR DESCRIPTION
## Summary
Addresses #126 by tightening the public project detail page hierarchy and media composition.

## Changes
- reworked the project detail hero into a clearer summary card, quick-facts grid, and stack section
- added contextual panel headers and media captioning so overview, collaborators, milestones, and screenshots read as a deliberate composition
- kept screenshot carousel behavior intact while improving the surrounding layout balance
- extended client tests to cover the new detail-page structure

## Verification
- npm test
- npm run build
- npm run lint
- dotnet build ProjectPortfolio2026.slnx -c Release
