### PR TITLE
Codex - Issue #92 - Normalize resume import candidates

### DIFF
--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportCandidateNormalizerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportCandidateNormalizerTests.cs
@@ -91,4 +91,35 @@ public sealed class ResumeImportCandidateNormalizerTests
             Assert.That(result.CandidateWorkHistory[1].JobRoles[0].JobTitle, Is.EqualTo("Consultant"));
         });
     }
+
+    [Test]
+    public void Normalize_TrimsDuplicateRawFieldKeysWithoutThrowingAndKeepsStructuredValue()
+    {
+        var result = ResumeImportCandidateNormalizer.Normalize(new ResumeImportParseResult
+        {
+            WorkHistory =
+            [
+                new ParsedWorkHistoryEntry
+                {
+                    EmployerName = "Northwind Health",
+                    JobTitle = "Engineer",
+                    RawFields = new Dictionary<string, string?>(StringComparer.Ordinal)
+                    {
+                        [" source-section "] = "   ",
+                        ["source-section"] = " experience ",
+                        ["detail"] = " imported "
+                    }
+                }
+            ]
+        });
+
+        var rawFields = result.CandidateWorkHistory[0].JobRoles[0].RawFields;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rawFields, Has.Count.EqualTo(2));
+            Assert.That(rawFields["source-section"], Is.EqualTo("experience"));
+            Assert.That(rawFields["detail"], Is.EqualTo("imported"));
+        });
+    }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportCandidateNormalizerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportCandidateNormalizerTests.cs
@@ -1,0 +1,94 @@
+using NUnit.Framework;
+using ProjectPortfolio2026.Server.Services.Implementations;
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Tests;
+
+[TestFixture]
+public sealed class ResumeImportCandidateNormalizerTests
+{
+    [Test]
+    public void Normalize_GroupsRolesByEmployerAndPreservesStructuredCandidates()
+    {
+        var result = ResumeImportCandidateNormalizer.Normalize(new ResumeImportParseResult
+        {
+            WorkHistory =
+            [
+                new ParsedWorkHistoryEntry
+                {
+                    EmployerName = " Northwind Health ",
+                    EmployerLocation = new ParsedLocation
+                    {
+                        City = " Chicago ",
+                        Region = " IL "
+                    },
+                    JobTitle = " Senior Software Engineer ",
+                    EmploymentDates = new ParsedDateRange
+                    {
+                        StartDateText = "Jan 2020",
+                        StartDate = new DateOnly(2020, 1, 1)
+                    },
+                    DescriptionLines = [" Built ATS export tooling ", " Built ATS export tooling "],
+                    Skills = [" C# ", "c#"],
+                    Technologies = [".NET", " .NET "]
+                },
+                new ParsedWorkHistoryEntry
+                {
+                    EmployerName = "Northwind Health",
+                    EmployerLocation = new ParsedLocation
+                    {
+                        City = "Chicago",
+                        Region = "IL"
+                    },
+                    JobTitle = "Staff Engineer",
+                    DescriptionMarkdown = " Led platform modernization. "
+                }
+            ],
+            GlobalSkills = [" .NET ", "c#", "C#"]
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.CandidateWorkHistory, Has.Count.EqualTo(1));
+            Assert.That(result.CandidateWorkHistory[0].CandidateId, Is.EqualTo("employer-001"));
+            Assert.That(result.CandidateWorkHistory[0].EmployerName, Is.EqualTo("Northwind Health"));
+            Assert.That(result.CandidateWorkHistory[0].EmployerLocation?.City, Is.EqualTo("Chicago"));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles, Has.Count.EqualTo(2));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[0].CandidateId, Is.EqualTo("role-001"));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[0].DescriptionLines, Is.EqualTo(new[] { "Built ATS export tooling" }));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[0].DescriptionMarkdown, Is.EqualTo("Built ATS export tooling"));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[0].Skills, Is.EqualTo(new[] { "C#" }));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[0].Technologies, Is.EqualTo(new[] { ".NET" }));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[1].DescriptionMarkdown, Is.EqualTo("Led platform modernization."));
+            Assert.That(result.GlobalSkills, Is.EqualTo(new[] { ".NET", "c#" }));
+        });
+    }
+
+    [Test]
+    public void Normalize_KeepsPartialEntriesWithoutMergingUnnamedEmployers()
+    {
+        var result = ResumeImportCandidateNormalizer.Normalize(new ResumeImportParseResult
+        {
+            WorkHistory =
+            [
+                new ParsedWorkHistoryEntry
+                {
+                    JobTitle = "Contractor",
+                    DescriptionLines = ["Shipped production fixes"]
+                },
+                new ParsedWorkHistoryEntry
+                {
+                    JobTitle = "Consultant",
+                    DescriptionLines = ["Provided delivery support"]
+                }
+            ]
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.CandidateWorkHistory, Has.Count.EqualTo(2));
+            Assert.That(result.CandidateWorkHistory[0].JobRoles[0].JobTitle, Is.EqualTo("Contractor"));
+            Assert.That(result.CandidateWorkHistory[1].JobRoles[0].JobTitle, Is.EqualTo("Consultant"));
+        });
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportControllerTests.cs
@@ -43,7 +43,7 @@ public sealed class ResumeImportControllerTests
     {
         var controller = new ResumeImportController(new StubResumeImportService
         {
-            Result = new ResumeImportParseResult
+            Result = new ResumeImportCandidateResult
             {
                 SourceFileName = "resume.pdf",
                 ParserName = "StubParser",
@@ -71,9 +71,9 @@ public sealed class ResumeImportControllerTests
     {
         public ResumeImportValidationException? ExceptionToThrow { get; set; }
 
-        public ResumeImportParseResult Result { get; set; } = new();
+        public ResumeImportCandidateResult Result { get; set; } = new();
 
-        public Task<ResumeImportParseResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default)
+        public Task<ResumeImportCandidateResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default)
         {
             if (ExceptionToThrow is not null)
             {

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportControllerTests.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server.Tests/ResumeImportControllerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using ProjectPortfolio2026.Server.Contracts;
+using ProjectPortfolio2026.Server.Contracts.Admin.ResumeImport;
 using ProjectPortfolio2026.Server.Controllers;
 using ProjectPortfolio2026.Server.Services.Interfaces;
 using ProjectPortfolio2026.Server.Services.ServiceModels;
@@ -45,17 +46,58 @@ public sealed class ResumeImportControllerTests
         {
             Result = new ResumeImportCandidateResult
             {
+                Person = new ParsedPerson
+                {
+                    FullName = "Taylor Jordan"
+                },
                 SourceFileName = "resume.pdf",
                 ParserName = "StubParser",
-                GlobalSkills = ["C#"]
+                GlobalSkills = ["C#"],
+                CandidateWorkHistory =
+                [
+                    new ResumeImportEmployerCandidate
+                    {
+                        CandidateId = "employer-001",
+                        EmployerName = "Northwind Health",
+                        JobRoles =
+                        [
+                            new ResumeImportJobRoleCandidate
+                            {
+                                CandidateId = "role-001",
+                                JobTitle = "Staff Engineer",
+                                DescriptionMarkdown = "Led modernization.",
+                                RawFields = new Dictionary<string, string?>(StringComparer.Ordinal)
+                                {
+                                    ["source-section"] = "experience"
+                                }
+                            }
+                        ]
+                    }
+                ]
             }
         });
 
         var result = await controller.ParseAsync(CreateFormFile("resume.pdf"), CancellationToken.None);
 
         Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
-        var response = (result.Result as OkObjectResult)?.Value;
-        Assert.That(response, Is.Not.Null);
+        var response = (result.Result as OkObjectResult)?.Value as ResumeImportParseResponse;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response?.Person?.FullName, Is.EqualTo("Taylor Jordan"));
+            Assert.That(response?.SourceFileName, Is.EqualTo("resume.pdf"));
+            Assert.That(response?.ParserName, Is.EqualTo("StubParser"));
+            Assert.That(response?.GlobalSkills, Is.EqualTo(new[] { "C#" }));
+            Assert.That(response?.CandidateWorkHistory, Has.Count.EqualTo(1));
+            Assert.That(response?.CandidateWorkHistory[0].CandidateId, Is.EqualTo("employer-001"));
+            Assert.That(response?.CandidateWorkHistory[0].EmployerName, Is.EqualTo("Northwind Health"));
+            Assert.That(response?.CandidateWorkHistory[0].JobRoles, Has.Count.EqualTo(1));
+            Assert.That(response?.CandidateWorkHistory[0].JobRoles[0].CandidateId, Is.EqualTo("role-001"));
+            Assert.That(response?.CandidateWorkHistory[0].JobRoles[0].JobTitle, Is.EqualTo("Staff Engineer"));
+            Assert.That(response?.CandidateWorkHistory[0].JobRoles[0].DescriptionMarkdown, Is.EqualTo("Led modernization."));
+            Assert.That(response?.CandidateWorkHistory[0].JobRoles[0].RawFields["source-section"], Is.EqualTo("experience"));
+        });
     }
 
     private static FormFile CreateFormFile(string fileName)

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Admin/ResumeImport/ResumeImportParseResponse.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Contracts/Admin/ResumeImport/ResumeImportParseResponse.cs
@@ -6,7 +6,7 @@ public sealed class ResumeImportParseResponse : ApiResponseDto
 {
     public ResumeImportPersonResponse? Person { get; set; }
 
-    public List<ResumeImportWorkHistoryEntryResponse> WorkHistory { get; set; } = [];
+    public List<ResumeImportEmployerCandidateResponse> CandidateWorkHistory { get; set; } = [];
 
     public List<string> GlobalSkills { get; set; } = [];
 
@@ -57,11 +57,20 @@ public sealed class ResumeImportLocationResponse
     public string? DisplayText { get; set; }
 }
 
-public sealed class ResumeImportWorkHistoryEntryResponse
+public sealed class ResumeImportEmployerCandidateResponse
 {
+    public string CandidateId { get; set; } = string.Empty;
+
     public string? EmployerName { get; set; }
 
     public ResumeImportLocationResponse? EmployerLocation { get; set; }
+
+    public List<ResumeImportJobRoleCandidateResponse> JobRoles { get; set; } = [];
+}
+
+public sealed class ResumeImportJobRoleCandidateResponse
+{
+    public string CandidateId { get; set; } = string.Empty;
 
     public string? JobTitle { get; set; }
 

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/ResumeImportContractMapper.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Mappers/ResumeImportContractMapper.cs
@@ -5,12 +5,12 @@ namespace ProjectPortfolio2026.Server.Mappers;
 
 public static class ResumeImportContractMapper
 {
-    public static ResumeImportParseResponse Map(ResumeImportParseResult result)
+    public static ResumeImportParseResponse Map(ResumeImportCandidateResult result)
     {
         return new ResumeImportParseResponse
         {
             Person = Map(result.Person),
-            WorkHistory = result.WorkHistory.Select(Map).ToList(),
+            CandidateWorkHistory = result.CandidateWorkHistory.Select(Map).ToList(),
             GlobalSkills = [.. result.GlobalSkills],
             ProfessionalSummary = result.ProfessionalSummary,
             RawText = result.RawText,
@@ -59,30 +59,40 @@ public static class ResumeImportContractMapper
         };
     }
 
-    private static ResumeImportWorkHistoryEntryResponse Map(ParsedWorkHistoryEntry entry)
+    private static ResumeImportEmployerCandidateResponse Map(ResumeImportEmployerCandidate candidate)
     {
-        return new ResumeImportWorkHistoryEntryResponse
+        return new ResumeImportEmployerCandidateResponse
         {
-            EmployerName = entry.EmployerName,
-            EmployerLocation = Map(entry.EmployerLocation),
-            JobTitle = entry.JobTitle,
-            EmploymentType = entry.EmploymentType,
-            SupervisorName = entry.SupervisorName,
+            CandidateId = candidate.CandidateId,
+            EmployerName = candidate.EmployerName,
+            EmployerLocation = Map(candidate.EmployerLocation),
+            JobRoles = candidate.JobRoles.Select(Map).ToList()
+        };
+    }
+
+    private static ResumeImportJobRoleCandidateResponse Map(ResumeImportJobRoleCandidate candidate)
+    {
+        return new ResumeImportJobRoleCandidateResponse
+        {
+            CandidateId = candidate.CandidateId,
+            JobTitle = candidate.JobTitle,
+            EmploymentType = candidate.EmploymentType,
+            SupervisorName = candidate.SupervisorName,
             EmploymentDates = new ResumeImportDateRangeResponse
             {
-                StartDateText = entry.EmploymentDates.StartDateText,
-                EndDateText = entry.EmploymentDates.EndDateText,
-                StartDate = entry.EmploymentDates.StartDate,
-                EndDate = entry.EmploymentDates.EndDate,
-                IsCurrentRole = entry.EmploymentDates.IsCurrentRole
+                StartDateText = candidate.EmploymentDates.StartDateText,
+                EndDateText = candidate.EmploymentDates.EndDateText,
+                StartDate = candidate.EmploymentDates.StartDate,
+                EndDate = candidate.EmploymentDates.EndDate,
+                IsCurrentRole = candidate.EmploymentDates.IsCurrentRole
             },
-            DescriptionLines = [.. entry.DescriptionLines],
-            DescriptionMarkdown = entry.DescriptionMarkdown,
-            Skills = [.. entry.Skills],
-            Technologies = [.. entry.Technologies],
-            Tags = [.. entry.Tags],
-            RawRoleText = entry.RawRoleText,
-            RawFields = new Dictionary<string, string?>(entry.RawFields, StringComparer.Ordinal)
+            DescriptionLines = [.. candidate.DescriptionLines],
+            DescriptionMarkdown = candidate.DescriptionMarkdown,
+            Skills = [.. candidate.Skills],
+            Technologies = [.. candidate.Technologies],
+            Tags = [.. candidate.Tags],
+            RawRoleText = candidate.RawRoleText,
+            RawFields = new Dictionary<string, string?>(candidate.RawFields, StringComparer.Ordinal)
         };
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportCandidateNormalizer.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportCandidateNormalizer.cs
@@ -184,12 +184,32 @@ public static class ResumeImportCandidateNormalizer
 
     private static Dictionary<string, string?> NormalizeRawFields(Dictionary<string, string?> rawFields)
     {
-        return rawFields
-            .Where(pair => !string.IsNullOrWhiteSpace(pair.Key))
-            .ToDictionary(
-                pair => pair.Key.Trim(),
-                pair => NormalizeText(pair.Value),
-                StringComparer.Ordinal);
+        var normalized = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        foreach (var pair in rawFields)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                continue;
+            }
+
+            var key = pair.Key.Trim();
+            var value = NormalizeText(pair.Value);
+
+            if (normalized.TryGetValue(key, out var existingValue))
+            {
+                if (existingValue is null && value is not null)
+                {
+                    normalized[key] = value;
+                }
+
+                continue;
+            }
+
+            normalized[key] = value;
+        }
+
+        return normalized;
     }
 
     private static List<string> NormalizeValues(IEnumerable<string?> values)

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportCandidateNormalizer.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportCandidateNormalizer.cs
@@ -1,0 +1,220 @@
+using ProjectPortfolio2026.Server.Services.ServiceModels;
+
+namespace ProjectPortfolio2026.Server.Services.Implementations;
+
+public static class ResumeImportCandidateNormalizer
+{
+    public static ResumeImportCandidateResult Normalize(ResumeImportParseResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new ResumeImportCandidateResult
+        {
+            Person = NormalizePerson(result.Person),
+            CandidateWorkHistory = NormalizeWorkHistory(result.WorkHistory),
+            GlobalSkills = NormalizeValues(result.GlobalSkills),
+            ProfessionalSummary = NormalizeText(result.ProfessionalSummary),
+            RawText = NormalizeText(result.RawText),
+            SourceFileName = NormalizeText(result.SourceFileName),
+            ParserName = NormalizeText(result.ParserName)
+        };
+    }
+
+    private static ParsedPerson? NormalizePerson(ParsedPerson? person)
+    {
+        if (person is null)
+        {
+            return null;
+        }
+
+        return new ParsedPerson
+        {
+            FullName = NormalizeText(person.FullName),
+            FirstName = NormalizeText(person.FirstName),
+            MiddleName = NormalizeText(person.MiddleName),
+            LastName = NormalizeText(person.LastName),
+            Headline = NormalizeText(person.Headline),
+            EmailAddress = NormalizeText(person.EmailAddress),
+            PhoneNumbers = NormalizeValues(person.PhoneNumbers),
+            Location = NormalizeLocation(person.Location),
+            SocialProfiles = NormalizeValues(person.SocialProfiles)
+        };
+    }
+
+    private static List<ResumeImportEmployerCandidate> NormalizeWorkHistory(IEnumerable<ParsedWorkHistoryEntry> workHistory)
+    {
+        var candidates = new List<ResumeImportEmployerCandidate>();
+        var employerLookup = new Dictionary<string, int>(StringComparer.Ordinal);
+        var employerCount = 0;
+        var roleCount = 0;
+
+        foreach (var entry in workHistory)
+        {
+            var employerName = NormalizeText(entry.EmployerName);
+            var employerLocation = NormalizeLocation(entry.EmployerLocation);
+            var employerKey = CreateEmployerKey(employerName, employerLocation, employerCount);
+
+            if (!employerLookup.TryGetValue(employerKey, out var index))
+            {
+                employerCount++;
+                index = candidates.Count;
+                employerLookup[employerKey] = index;
+                candidates.Add(new ResumeImportEmployerCandidate
+                {
+                    CandidateId = $"employer-{employerCount:D3}",
+                    EmployerName = employerName,
+                    EmployerLocation = employerLocation,
+                    JobRoles = []
+                });
+            }
+
+            roleCount++;
+            candidates[index].JobRoles.Add(new ResumeImportJobRoleCandidate
+            {
+                CandidateId = $"role-{roleCount:D3}",
+                JobTitle = NormalizeText(entry.JobTitle),
+                EmploymentDates = NormalizeDateRange(entry.EmploymentDates),
+                EmploymentType = NormalizeText(entry.EmploymentType),
+                SupervisorName = NormalizeText(entry.SupervisorName),
+                DescriptionLines = NormalizeValues(entry.DescriptionLines),
+                DescriptionMarkdown = NormalizeDescriptionMarkdown(entry.DescriptionMarkdown, entry.DescriptionLines),
+                Skills = NormalizeValues(entry.Skills),
+                Technologies = NormalizeValues(entry.Technologies),
+                Tags = NormalizeValues(entry.Tags),
+                RawRoleText = NormalizeText(entry.RawRoleText),
+                RawFields = NormalizeRawFields(entry.RawFields)
+            });
+        }
+
+        return candidates;
+    }
+
+    private static string CreateEmployerKey(string? employerName, ParsedLocation? employerLocation, int fallbackIndex)
+    {
+        var locationKey = NormalizeLocationKey(employerLocation);
+
+        if (!string.IsNullOrEmpty(employerName))
+        {
+            return $"{employerName.ToUpperInvariant()}|{locationKey}";
+        }
+
+        return $"UNNAMED|{locationKey}|{fallbackIndex:D3}";
+    }
+
+    private static string NormalizeLocationKey(ParsedLocation? location)
+    {
+        if (location is null)
+        {
+            return string.Empty;
+        }
+
+        var locationParts = new[]
+        {
+            location.StreetAddress1,
+            location.StreetAddress2,
+            location.City,
+            location.Region,
+            location.PostalCode,
+            location.Country,
+            location.DisplayText
+        };
+
+        return string.Join("|", locationParts.Select(part => NormalizeText(part)?.ToUpperInvariant() ?? string.Empty));
+    }
+
+    private static ParsedDateRange NormalizeDateRange(ParsedDateRange? dates)
+    {
+        if (dates is null)
+        {
+            return new ParsedDateRange();
+        }
+
+        return new ParsedDateRange
+        {
+            StartDateText = NormalizeText(dates.StartDateText),
+            EndDateText = NormalizeText(dates.EndDateText),
+            StartDate = dates.StartDate,
+            EndDate = dates.EndDate,
+            IsCurrentRole = dates.IsCurrentRole
+        };
+    }
+
+    private static ParsedLocation? NormalizeLocation(ParsedLocation? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        var normalized = new ParsedLocation
+        {
+            StreetAddress1 = NormalizeText(location.StreetAddress1),
+            StreetAddress2 = NormalizeText(location.StreetAddress2),
+            City = NormalizeText(location.City),
+            Region = NormalizeText(location.Region),
+            PostalCode = NormalizeText(location.PostalCode),
+            Country = NormalizeText(location.Country),
+            DisplayText = NormalizeText(location.DisplayText)
+        };
+
+        return normalized.StreetAddress1 is null
+            && normalized.StreetAddress2 is null
+            && normalized.City is null
+            && normalized.Region is null
+            && normalized.PostalCode is null
+            && normalized.Country is null
+            && normalized.DisplayText is null
+                ? null
+                : normalized;
+    }
+
+    private static string? NormalizeDescriptionMarkdown(string? descriptionMarkdown, IEnumerable<string> descriptionLines)
+    {
+        var normalizedMarkdown = NormalizeText(descriptionMarkdown);
+        if (normalizedMarkdown is not null)
+        {
+            return normalizedMarkdown;
+        }
+
+        var normalizedLines = NormalizeValues(descriptionLines);
+        return normalizedLines.Count == 0
+            ? null
+            : string.Join(Environment.NewLine, normalizedLines);
+    }
+
+    private static Dictionary<string, string?> NormalizeRawFields(Dictionary<string, string?> rawFields)
+    {
+        return rawFields
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Key))
+            .ToDictionary(
+                pair => pair.Key.Trim(),
+                pair => NormalizeText(pair.Value),
+                StringComparer.Ordinal);
+    }
+
+    private static List<string> NormalizeValues(IEnumerable<string?> values)
+    {
+        var normalized = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var value in values)
+        {
+            var trimmed = NormalizeText(value);
+            if (trimmed is null || !seen.Add(trimmed))
+            {
+                continue;
+            }
+
+            normalized.Add(trimmed);
+        }
+
+        return normalized;
+    }
+
+    private static string? NormalizeText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Trim();
+    }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportService.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Implementations/ResumeImportService.cs
@@ -7,7 +7,7 @@ public sealed class ResumeImportService(
     IResumeImportFileStore resumeImportFileStore,
     IResumeParserService resumeParserService) : IResumeImportService
 {
-    public async Task<ResumeImportParseResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default)
+    public async Task<ResumeImportCandidateResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default)
     {
         await using var stagedFile = await resumeImportFileStore.StageAsync(file, cancellationToken);
         await using var content = File.OpenRead(stagedFile.StoredFilePath);
@@ -15,6 +15,6 @@ public sealed class ResumeImportService(
         var result = await resumeParserService.ParseAsync(content, stagedFile.OriginalFileName, cancellationToken);
         result.SourceFileName ??= stagedFile.OriginalFileName;
 
-        return result;
+        return ResumeImportCandidateNormalizer.Normalize(result);
     }
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeImportService.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/Interfaces/IResumeImportService.cs
@@ -4,5 +4,5 @@ namespace ProjectPortfolio2026.Server.Services.Interfaces;
 
 public interface IResumeImportService
 {
-    Task<ResumeImportParseResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default);
+    Task<ResumeImportCandidateResult> ParseAsync(IFormFile file, CancellationToken cancellationToken = default);
 }

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportCandidateResult.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportCandidateResult.cs
@@ -1,0 +1,18 @@
+namespace ProjectPortfolio2026.Server.Services.ServiceModels;
+
+public sealed class ResumeImportCandidateResult
+{
+    public ParsedPerson? Person { get; set; }
+
+    public List<ResumeImportEmployerCandidate> CandidateWorkHistory { get; set; } = [];
+
+    public List<string> GlobalSkills { get; set; } = [];
+
+    public string? ProfessionalSummary { get; set; }
+
+    public string? RawText { get; set; }
+
+    public string? SourceFileName { get; set; }
+
+    public string? ParserName { get; set; }
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportEmployerCandidate.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportEmployerCandidate.cs
@@ -1,0 +1,12 @@
+namespace ProjectPortfolio2026.Server.Services.ServiceModels;
+
+public sealed class ResumeImportEmployerCandidate
+{
+    public string CandidateId { get; init; } = string.Empty;
+
+    public string? EmployerName { get; init; }
+
+    public ParsedLocation? EmployerLocation { get; init; }
+
+    public List<ResumeImportJobRoleCandidate> JobRoles { get; init; } = [];
+}

--- a/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportJobRoleCandidate.cs
+++ b/ProjectPortfolio2026/ProjectPortfolio2026.Server/Services/ServiceModels/ResumeImportJobRoleCandidate.cs
@@ -1,0 +1,28 @@
+namespace ProjectPortfolio2026.Server.Services.ServiceModels;
+
+public sealed class ResumeImportJobRoleCandidate
+{
+    public string CandidateId { get; init; } = string.Empty;
+
+    public string? JobTitle { get; init; }
+
+    public ParsedDateRange EmploymentDates { get; init; } = new();
+
+    public string? EmploymentType { get; init; }
+
+    public string? SupervisorName { get; init; }
+
+    public List<string> DescriptionLines { get; init; } = [];
+
+    public string? DescriptionMarkdown { get; init; }
+
+    public List<string> Skills { get; init; } = [];
+
+    public List<string> Technologies { get; init; } = [];
+
+    public List<string> Tags { get; init; } = [];
+
+    public string? RawRoleText { get; init; }
+
+    public Dictionary<string, string?> RawFields { get; init; } = new(StringComparer.Ordinal);
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeImport.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/api/resumeImport.ts
@@ -7,7 +7,7 @@ export interface ResumeImportParseResponse {
     professionalSummary?: string | null;
     rawText?: string | null;
     globalSkills: string[];
-    workHistory: ResumeImportWorkHistoryEntry[];
+    candidateWorkHistory: ResumeImportEmployerCandidate[];
     person?: ResumeImportPerson | null;
 }
 
@@ -19,10 +19,17 @@ export interface ResumeImportPerson {
     socialProfiles: string[];
 }
 
-export interface ResumeImportWorkHistoryEntry {
+export interface ResumeImportEmployerCandidate {
+    candidateId: string;
     employerName?: string | null;
+    jobRoles: ResumeImportJobRoleCandidate[];
+}
+
+export interface ResumeImportJobRoleCandidate {
+    candidateId: string;
     jobTitle?: string | null;
     descriptionLines: string[];
+    descriptionMarkdown?: string | null;
     skills: string[];
     technologies: string[];
 }

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeImportPage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeImportPage.test.tsx
@@ -27,13 +27,19 @@ describe('ResumeImportPage', () => {
             sourceFileName: 'resume.pdf',
             parserName: 'StubParser',
             globalSkills: ['C#', '.NET'],
-            workHistory: [
+            candidateWorkHistory: [
                 {
+                    candidateId: 'employer-001',
                     employerName: 'Northwind Health',
-                    jobTitle: 'Senior Software Engineer',
-                    descriptionLines: [],
-                    skills: [],
-                    technologies: []
+                    jobRoles: [
+                        {
+                            candidateId: 'role-001',
+                            jobTitle: 'Senior Software Engineer',
+                            descriptionLines: [],
+                            skills: [],
+                            technologies: []
+                        }
+                    ]
                 }
             ],
             person: {
@@ -67,7 +73,7 @@ describe('ResumeImportPage', () => {
         expect(await screen.findByRole('heading', { name: 'Candidate data is ready for the next import stages' })).toBeInTheDocument();
         expect(screen.getByText('resume.pdf')).toBeInTheDocument();
         expect(screen.getByText('1 role candidate')).toBeInTheDocument();
-        expect(screen.getByText('2 global skills')).toBeInTheDocument();
+        expect(screen.getByText('1 employer group and 2 global skills')).toBeInTheDocument();
         expect(screen.getAllByText('Portfolio Owner').length).toBeGreaterThan(0);
     });
 });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeImportPage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/components/admin/ResumeImportPage.tsx
@@ -53,7 +53,8 @@ export function ResumeImportPage({
         }
     }
 
-    const parsedWorkHistoryCount = parseResult?.workHistory.length ?? 0;
+    const parsedEmployerCount = parseResult?.candidateWorkHistory.length ?? 0;
+    const parsedWorkHistoryCount = parseResult?.candidateWorkHistory.reduce((count, employer) => count + employer.jobRoles.length, 0) ?? 0;
     const parsedSkillsCount = parseResult?.globalSkills.length ?? 0;
     const parserName = parseResult?.parserName?.trim() || 'Pending parser implementation';
 
@@ -174,7 +175,7 @@ export function ResumeImportPage({
                                     <article className="resume-import-preview-card">
                                         <span className="stat-label">Parsed candidates</span>
                                         <strong>{formatCandidateCount(parsedWorkHistoryCount, 'role candidate', 'role candidates')}</strong>
-                                        <p>{formatCandidateCount(parsedSkillsCount, 'global skill', 'global skills')}</p>
+                                        <p>{formatCandidateCount(parsedEmployerCount, 'employer group', 'employer groups')} and {formatCandidateCount(parsedSkillsCount, 'global skill', 'global skills')}</p>
                                     </article>
                                     <article className="resume-import-preview-card">
                                         <span className="stat-label">Detected person</span>


### PR DESCRIPTION
## Summary
- normalize raw resume parser output into structured employer and role candidates before returning it to the admin import flow
- update the admin import API contract and client preview to consume grouped candidate work history counts
- add focused normalization tests for grouped employers, deduped candidate fields, and partial-entry handling

## Testing
- npm test
- npm run build
- dotnet build .\ProjectPortfolio2026.slnx -c Release
- dotnet test .\ProjectPortfolio2026.slnx -c Release --no-build

Closes #92