### PR TITLE
Codex - Issue #106 - Add filtered resume PDF export

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/package-lock.json
+++ b/ProjectPortfolio2026/projectportfolio2026.client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "projectportfolio2026.client",
       "version": "0.0.0",
       "dependencies": {
+        "@fontpkg/unifont": "^15.0.1",
+        "@pdf-lib/fontkit": "^1.1.1",
+        "pdf-lib": "^1.17.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6"
       },
@@ -712,6 +715,12 @@
         }
       }
     },
+    "node_modules/@fontpkg/unifont": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@fontpkg/unifont/-/unifont-15.0.1.tgz",
+      "integrity": "sha512-2cOKJsymtBTwb6tgjnsUa3tNoD1/Ubg7NmOxdHzl+wZe3evrkoZyLU2fUWwmWrpM2PLKbiqi+AnwdBgHT8herg==",
+      "license": "SEE LICENSE IN README.md"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -841,6 +850,33 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pdf-lib/fontkit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/fontkit/-/fontkit-1.1.1.tgz",
+      "integrity": "sha512-KjMd7grNapIWS/Dm0gvfHEilSyAmeLvrEGVcqLGi0VYebuqqzTbgF29efCx7tvx+IEbG3zQciRSWl3GkUSvjZg==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3371,6 +3407,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3423,6 +3465,24 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/ProjectPortfolio2026/projectportfolio2026.client/package.json
+++ b/ProjectPortfolio2026/projectportfolio2026.client/package.json
@@ -13,6 +13,9 @@
     "test:coverage": "vitest run --coverage --pool=threads --maxWorkers=1 --no-file-parallelism"
   },
   "dependencies": {
+    "@fontpkg/unifont": "^15.0.1",
+    "@pdf-lib/fontkit": "^1.1.1",
+    "pdf-lib": "^1.17.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
   },

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/App.test.tsx
@@ -408,7 +408,7 @@ describe('App', () => {
         expect(screen.getByRole('button', { name: 'All employers' })).toHaveAttribute('aria-pressed', 'true');
         expect(screen.getByRole('button', { name: 'Top 3' })).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByRole('button', { name: 'Top 5' })).toHaveAttribute('aria-pressed', 'false');
-        expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Download PDF' })).toBeEnabled();
         expect(screen.getByRole('link', { name: 'Download Resume' })).toHaveAttribute('href', 'https://cdn.example.dev/resume.pdf');
         expect(screen.getByText('ATS-friendly PDF.')).toBeInTheDocument();
     });

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Employer, PortfolioProfile, ResumeConfiguration } from '../../app/types';
@@ -22,6 +25,52 @@ import { useWorkHistory } from '../../hooks/useWorkHistory';
 const mockUsePortfolioProfile = vi.mocked(usePortfolioProfile);
 const mockUseResumeConfiguration = vi.mocked(useResumeConfiguration);
 const mockUseWorkHistory = vi.mocked(useWorkHistory);
+const originalCreateObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+const originalRevokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+const unicodePdfFontBytes = readFileSync(resolve(process.cwd(), 'node_modules', '@fontpkg', 'unifont', 'unifont-15.0.01.ttf'));
+
+function restoreUrlProperty(name: 'createObjectURL' | 'revokeObjectURL', descriptor?: PropertyDescriptor) {
+    if (descriptor) {
+        Object.defineProperty(URL, name, descriptor);
+        return;
+    }
+
+    Reflect.deleteProperty(URL, name);
+}
+
+function mockPdfFontFetch() {
+    const fontBytes = unicodePdfFontBytes;
+    const fontArrayBuffer = fontBytes.buffer.slice(fontBytes.byteOffset, fontBytes.byteOffset + fontBytes.byteLength);
+    const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => fontArrayBuffer.slice(0)
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+function mockPdfDownloadSupport() {
+    const createObjectUrl = vi.fn<(object: Blob) => string>(() => 'blob:resume');
+    const revokeObjectUrl = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        writable: true,
+        value: createObjectUrl
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        writable: true,
+        value: revokeObjectUrl
+    });
+    const anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    return {
+        anchorClickSpy,
+        createObjectUrl,
+        fetchMock: mockPdfFontFetch(),
+        revokeObjectUrl
+    };
+}
 
 function createProfile(overrides: Partial<PortfolioProfile> = {}): PortfolioProfile {
     return {
@@ -74,6 +123,9 @@ describe('ResumePage', () => {
         cleanup();
         vi.useRealTimers();
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        restoreUrlProperty('createObjectURL', originalCreateObjectUrlDescriptor);
+        restoreUrlProperty('revokeObjectURL', originalRevokeObjectUrlDescriptor);
     });
 
     beforeEach(() => {
@@ -192,19 +244,8 @@ describe('ResumePage', () => {
     });
 
     it('exports the currently filtered resume view as a PDF download', async () => {
-        const createObjectUrl = vi.fn<(object: Blob) => string>(() => 'blob:resume');
-        const revokeObjectUrl = vi.fn();
-        Object.defineProperty(URL, 'createObjectURL', {
-            configurable: true,
-            writable: true,
-            value: createObjectUrl
-        });
-        Object.defineProperty(URL, 'revokeObjectURL', {
-            configurable: true,
-            writable: true,
-            value: revokeObjectUrl
-        });
-        const anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+        vi.useRealTimers();
+        const { anchorClickSpy, createObjectUrl, revokeObjectUrl } = mockPdfDownloadSupport();
 
         mockUseWorkHistory.mockReturnValue({
             employers: [
@@ -244,21 +285,20 @@ describe('ResumePage', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Last 5 years' }));
         fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
 
-        expect(screen.getByText('PDF download started.')).toBeInTheDocument();
+        expect(await screen.findByText('PDF download started.')).toBeInTheDocument();
         expect(createObjectUrl).toHaveBeenCalledTimes(1);
         expect(anchorClickSpy).toHaveBeenCalledTimes(1);
         expect(revokeObjectUrl).toHaveBeenCalledWith('blob:resume');
 
         const pdfBlob = createObjectUrl.mock.calls[0]?.[0] as unknown as Blob;
-        const pdfText = await pdfBlob.text();
         expect(pdfBlob.type).toBe('application/pdf');
-        expect(pdfText).toContain('%PDF-1.4');
-        expect(pdfText).toContain('Time Window: Last 5 years');
-        expect(pdfText).toContain('Current Employer');
-        expect(pdfText).not.toContain('Legacy Employer');
+        const pdfBytes = new Uint8Array(await pdfBlob.arrayBuffer());
+        const pdfHeader = new TextDecoder().decode(pdfBytes.slice(0, 8));
+        expect(pdfHeader).toContain('%PDF-');
     });
 
     it('shows a clean error when the PDF export pipeline is unavailable', () => {
+        vi.useRealTimers();
         Object.defineProperty(URL, 'createObjectURL', {
             configurable: true,
             writable: true,
@@ -269,7 +309,53 @@ describe('ResumePage', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
 
-        expect(screen.getByText('Unable to export the resume PDF right now.')).toBeInTheDocument();
+        return screen.findByText('Unable to export the resume PDF right now.')
+            .then(errorBanner => {
+                expect(errorBanner).toBeInTheDocument();
+            });
+    });
+
+    it('keeps PDF export available while resume source configuration is still loading', async () => {
+        vi.useRealTimers();
+        const { createObjectUrl } = mockPdfDownloadSupport();
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: null,
+            isLoading: true,
+            error: null,
+            isMissing: false
+        });
+
+        render(<ResumePage />);
+
+        const downloadButton = screen.getByRole('button', { name: 'Download PDF' });
+        expect(downloadButton).toBeEnabled();
+
+        fireEvent.click(downloadButton);
+
+        expect(await screen.findByText('PDF download started.')).toBeInTheDocument();
+        expect(createObjectUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps PDF export available when resume source configuration fails', async () => {
+        vi.useRealTimers();
+        const { createObjectUrl } = mockPdfDownloadSupport();
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: null,
+            isLoading: false,
+            error: 'Resume configuration failed.',
+            isMissing: false
+        });
+
+        render(<ResumePage />);
+
+        expect(screen.getByText('Resume configuration failed.')).toBeInTheDocument();
+        const downloadButton = screen.getByRole('button', { name: 'Download PDF' });
+        expect(downloadButton).toBeEnabled();
+
+        fireEvent.click(downloadButton);
+
+        expect(await screen.findByText('PDF download started.')).toBeInTheDocument();
+        expect(createObjectUrl).toHaveBeenCalledTimes(1);
     });
 
     it('renders structured summary, skill highlights, and full experience history', () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -73,6 +73,7 @@ describe('ResumePage', () => {
     afterEach(() => {
         cleanup();
         vi.useRealTimers();
+        vi.restoreAllMocks();
     });
 
     beforeEach(() => {
@@ -188,6 +189,87 @@ describe('ResumePage', () => {
         expect(screen.getByRole('link', { name: 'Download Resume' })).toHaveAttribute('href', 'https://cdn.example.dev/resume.pdf');
         expect(screen.getByText('ATS-friendly PDF.')).toBeInTheDocument();
         expect(screen.getAllByText('Hosted file').length).toBeGreaterThan(0);
+    });
+
+    it('exports the currently filtered resume view as a PDF download', async () => {
+        const createObjectUrl = vi.fn<(object: Blob) => string>(() => 'blob:resume');
+        const revokeObjectUrl = vi.fn();
+        Object.defineProperty(URL, 'createObjectURL', {
+            configurable: true,
+            writable: true,
+            value: createObjectUrl
+        });
+        Object.defineProperty(URL, 'revokeObjectURL', {
+            configurable: true,
+            writable: true,
+            value: revokeObjectUrl
+        });
+        const anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+        mockUseWorkHistory.mockReturnValue({
+            employers: [
+                createEmployer(1, {
+                    name: 'Current Employer',
+                    jobRoles: [
+                        {
+                            role: 'Staff Engineer',
+                            startDate: '2024-02-01',
+                            endDate: null,
+                            descriptionMarkdown: 'Owning platform and delivery work.',
+                            skills: ['Leadership'],
+                            technologies: ['React']
+                        }
+                    ]
+                }),
+                createEmployer(2, {
+                    name: 'Legacy Employer',
+                    jobRoles: [
+                        {
+                            role: 'Analyst',
+                            startDate: '2015-01-01',
+                            endDate: '2017-12-20',
+                            descriptionMarkdown: 'Early delivery work.',
+                            skills: ['Support'],
+                            technologies: ['SQL Server']
+                        }
+                    ]
+                })
+            ],
+            isLoading: false,
+            error: null
+        });
+
+        render(<ResumePage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Last 5 years' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+        expect(screen.getByText('PDF download started.')).toBeInTheDocument();
+        expect(createObjectUrl).toHaveBeenCalledTimes(1);
+        expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+        expect(revokeObjectUrl).toHaveBeenCalledWith('blob:resume');
+
+        const pdfBlob = createObjectUrl.mock.calls[0]?.[0] as unknown as Blob;
+        const pdfText = await pdfBlob.text();
+        expect(pdfBlob.type).toBe('application/pdf');
+        expect(pdfText).toContain('%PDF-1.4');
+        expect(pdfText).toContain('Time Window: Last 5 years');
+        expect(pdfText).toContain('Current Employer');
+        expect(pdfText).not.toContain('Legacy Employer');
+    });
+
+    it('shows a clean error when the PDF export pipeline is unavailable', () => {
+        Object.defineProperty(URL, 'createObjectURL', {
+            configurable: true,
+            writable: true,
+            value: undefined
+        });
+
+        render(<ResumePage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }));
+
+        expect(screen.getByText('Unable to export the resume PDF right now.')).toBeInTheDocument();
     });
 
     it('renders structured summary, skill highlights, and full experience history', () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -4,6 +4,7 @@ import { formatProjectDates } from '../../appSupport';
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
 import { useResumeConfiguration } from '../../hooks/useResumeConfiguration';
 import { useWorkHistory } from '../../hooks/useWorkHistory';
+import { downloadResumePdf } from './resumePdf';
 
 interface ResumeDateValue {
     label: string;
@@ -298,6 +299,8 @@ function getResumeViewSummary(
 export function ResumePage() {
     const [selectedTimeFilterKey, setSelectedTimeFilterKey] = useState<ResumeTimeFilterKey>('all');
     const [selectedEmployerLimitKey, setSelectedEmployerLimitKey] = useState<ResumeEmployerLimitKey>('all');
+    const [pdfExportFeedback, setPdfExportFeedback] = useState<string | null>(null);
+    const [pdfExportError, setPdfExportError] = useState<string | null>(null);
     const {
         profile,
         isLoading: isProfileLoading,
@@ -377,12 +380,39 @@ export function ResumePage() {
         totalRoleCount
     );
     const resumeSourceTypeLabel = resumeConfiguration?.sourceType === 'embed' ? 'Embed source' : 'Hosted file';
+    const canExportPdf = !isLoading && errors.length === 0;
+
+    function handleDownloadPdf() {
+        try {
+            downloadResumePdf({
+                profile,
+                employers: filteredEmployers,
+                activeTimeWindowLabel: selectedTimeFilter.label,
+                activeEmployerLimitLabel: selectedEmployerLimit.label,
+                viewSummary: resumeViewSummary,
+                generatedAt: new Date(),
+                skillHighlights: skillHighlights.map(highlight => highlight.label),
+                technologyHighlights: technologyHighlights.map(highlight => highlight.label)
+            });
+            setPdfExportFeedback('PDF download started.');
+            setPdfExportError(null);
+        } catch {
+            setPdfExportFeedback(null);
+            setPdfExportError('Unable to export the resume PDF right now.');
+        }
+    }
 
     return (
         <main className="resume-page">
             {errors.map(error => (
                 <p key={error} className="status-banner error">{error}</p>
             ))}
+            {pdfExportError ? (
+                <p className="status-banner error">{pdfExportError}</p>
+            ) : null}
+            {pdfExportFeedback ? (
+                <p className="status-banner">{pdfExportFeedback}</p>
+            ) : null}
             {!errors.length && isLoading ? (
                 <p className="status-banner">Loading resume...</p>
             ) : null}
@@ -501,16 +531,21 @@ export function ResumePage() {
                         <div className="resume-action-card">
                             <div className="resume-action-copy">
                                 <span className="meta-label">PDF Export</span>
-                                <span className="resume-action-note">Issue #88</span>
+                                <span className="resume-action-note">
+                                    {canExportPdf
+                                        ? 'Reflects the active resume filters.'
+                                        : 'Available once resume data finishes loading.'}
+                                </span>
                             </div>
                             <button
                                 className="resume-action-button"
                                 type="button"
-                                disabled
-                                aria-disabled="true"
-                                aria-label="Download PDF">
+                                disabled={!canExportPdf}
+                                aria-disabled={!canExportPdf}
+                                aria-label="Download PDF"
+                                onClick={handleDownloadPdf}>
                                 <span>Download PDF</span>
-                                <span className="coming-soon-pill">Coming Soon</span>
+                                <span className="coming-soon-pill">{canExportPdf ? 'ATS-friendly' : 'Unavailable'}</span>
                             </button>
                         </div>
                         <div className="resume-action-card">

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -4,7 +4,6 @@ import { formatProjectDates } from '../../appSupport';
 import { usePortfolioProfile } from '../../hooks/usePortfolioProfile';
 import { useResumeConfiguration } from '../../hooks/useResumeConfiguration';
 import { useWorkHistory } from '../../hooks/useWorkHistory';
-import { downloadResumePdf } from './resumePdf';
 
 interface ResumeDateValue {
     label: string;
@@ -299,6 +298,7 @@ function getResumeViewSummary(
 export function ResumePage() {
     const [selectedTimeFilterKey, setSelectedTimeFilterKey] = useState<ResumeTimeFilterKey>('all');
     const [selectedEmployerLimitKey, setSelectedEmployerLimitKey] = useState<ResumeEmployerLimitKey>('all');
+    const [isExportingPdf, setIsExportingPdf] = useState(false);
     const [pdfExportFeedback, setPdfExportFeedback] = useState<string | null>(null);
     const [pdfExportError, setPdfExportError] = useState<string | null>(null);
     const {
@@ -370,7 +370,9 @@ export function ResumePage() {
     const hasSummarySection = Boolean(profile?.contactHeadline?.trim() || profile?.availabilityHeadline?.trim() || summaryParagraphs.length > 0);
     const hasSkillsSection = skillHighlights.length > 0 || technologyHighlights.length > 0;
     const isLoading = isProfileLoading || isWorkHistoryLoading || isResumeConfigurationLoading;
+    const isResumePdfLoading = isProfileLoading || isWorkHistoryLoading || isExportingPdf;
     const errors = [profileError, workHistoryError, resumeConfigurationError].filter(Boolean);
+    const resumePdfErrors = [profileError, workHistoryError].filter(Boolean);
     const activeFilterCount = (selectedTimeFilter.key === 'all' ? 0 : 1) + (selectedEmployerLimit.key === 'all' ? 0 : 1);
     const resumeViewSummary = getResumeViewSummary(
         selectedTimeFilter,
@@ -380,11 +382,16 @@ export function ResumePage() {
         totalRoleCount
     );
     const resumeSourceTypeLabel = resumeConfiguration?.sourceType === 'embed' ? 'Embed source' : 'Hosted file';
-    const canExportPdf = !isLoading && errors.length === 0;
+    const canExportPdf = !isResumePdfLoading && resumePdfErrors.length === 0;
 
-    function handleDownloadPdf() {
+    async function handleDownloadPdf() {
+        setIsExportingPdf(true);
+        setPdfExportFeedback('Preparing PDF download...');
+        setPdfExportError(null);
+
         try {
-            downloadResumePdf({
+            const { downloadResumePdf } = await import('./resumePdf');
+            await downloadResumePdf({
                 profile,
                 employers: filteredEmployers,
                 activeTimeWindowLabel: selectedTimeFilter.label,
@@ -395,10 +402,11 @@ export function ResumePage() {
                 technologyHighlights: technologyHighlights.map(highlight => highlight.label)
             });
             setPdfExportFeedback('PDF download started.');
-            setPdfExportError(null);
         } catch {
             setPdfExportFeedback(null);
             setPdfExportError('Unable to export the resume PDF right now.');
+        } finally {
+            setIsExportingPdf(false);
         }
     }
 
@@ -534,7 +542,9 @@ export function ResumePage() {
                                 <span className="resume-action-note">
                                     {canExportPdf
                                         ? 'Reflects the active resume filters.'
-                                        : 'Available once resume data finishes loading.'}
+                                        : isExportingPdf
+                                            ? 'Preparing the latest filtered resume PDF.'
+                                            : 'Available once profile and work history finish loading.'}
                                 </span>
                             </div>
                             <button
@@ -545,7 +555,7 @@ export function ResumePage() {
                                 aria-label="Download PDF"
                                 onClick={handleDownloadPdf}>
                                 <span>Download PDF</span>
-                                <span className="coming-soon-pill">{canExportPdf ? 'ATS-friendly' : 'Unavailable'}</span>
+                                <span className="coming-soon-pill">{canExportPdf ? 'ATS-friendly' : isExportingPdf ? 'Preparing' : 'Unavailable'}</span>
                             </button>
                         </div>
                         <div className="resume-action-card">

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/resumePdf.test.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/resumePdf.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="node" />
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Employer, PortfolioProfile } from '../../app/types';
+import { buildResumePdfBytes, buildResumePdfTextLines } from './resumePdf';
+
+const unicodePdfFontBytes = readFileSync(resolve(process.cwd(), 'node_modules', '@fontpkg', 'unifont', 'unifont-15.0.01.ttf'));
+
+function createProfile(overrides: Partial<PortfolioProfile> = {}): PortfolioProfile {
+    return {
+        id: 1,
+        displayName: 'Łukasz Søren',
+        contactHeadline: 'Principal engineer focused on resilient delivery.',
+        contactIntro: 'Leading payment migrations for Łukasz, Søren, and multilingual platform teams.',
+        availabilityHeadline: 'Available for distributed senior product engineering roles.',
+        availabilitySummary: 'Open to remote-friendly opportunities with product ownership.',
+        contactMethods: [],
+        socialLinks: [],
+        ...overrides
+    };
+}
+
+function createEmployer(overrides: Partial<Employer> = {}): Employer {
+    return {
+        id: 1,
+        name: '株式会社サンプル',
+        city: 'Tokyo',
+        region: 'Tokyo',
+        country: 'Japan',
+        jobRoles: [
+            {
+                role: 'Staff Engineer',
+                startDate: '2023-01-01',
+                endDate: null,
+                descriptionMarkdown: 'Scaled multilingual resume exports for global hiring teams.',
+                skills: ['Architecture', 'Delivery'],
+                technologies: ['React', '.NET 10']
+            }
+        ],
+        ...overrides
+    };
+}
+
+function mockPdfFontFetch() {
+    const fontBytes = unicodePdfFontBytes;
+    const fontArrayBuffer = fontBytes.buffer.slice(fontBytes.byteOffset, fontBytes.byteOffset + fontBytes.byteLength);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => fontArrayBuffer.slice(0)
+    }));
+}
+
+describe('resumePdf', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('preserves unicode resume content in the generated text lines', () => {
+        const text = buildResumePdfTextLines({
+            profile: createProfile(),
+            employers: [createEmployer()],
+            activeTimeWindowLabel: 'Last 5 years',
+            activeEmployerLimitLabel: 'All employers',
+            viewSummary: 'Showing the current filtered resume view.',
+            generatedAt: new Date('2026-06-04T12:00:00Z'),
+            skillHighlights: ['Architecture'],
+            technologyHighlights: ['React']
+        }).join('\n');
+
+        expect(text).toContain('Łukasz Søren');
+        expect(text).toContain('Leading payment migrations for Łukasz, Søren, and multilingual platform teams.');
+        expect(text).toContain('株式会社サンプル');
+        expect(text).not.toContain('?ukasz');
+        expect(text).not.toContain('S?ren');
+        expect(text).not.toContain('????');
+    });
+
+    it('creates PDF bytes for unicode resume exports', async () => {
+        mockPdfFontFetch();
+
+        const bytes = await buildResumePdfBytes({
+            profile: createProfile(),
+            employers: [createEmployer()],
+            activeTimeWindowLabel: 'Last 5 years',
+            activeEmployerLimitLabel: 'All employers',
+            viewSummary: 'Showing the current filtered resume view.',
+            generatedAt: new Date('2026-06-04T12:00:00Z'),
+            skillHighlights: ['Architecture'],
+            technologyHighlights: ['React']
+        });
+
+        expect(bytes.length).toBeGreaterThan(0);
+        expect(new TextDecoder().decode(bytes.slice(0, 8))).toContain('%PDF-');
+    });
+});

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/resumePdf.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/resumePdf.ts
@@ -1,0 +1,385 @@
+import type { Employer, PortfolioContactMethod, PortfolioProfile, PortfolioSocialLink } from '../../app/types';
+
+export interface ResumePdfExportOptions {
+    profile: PortfolioProfile | null;
+    employers: Employer[];
+    activeTimeWindowLabel: string;
+    activeEmployerLimitLabel: string;
+    viewSummary: string;
+    generatedAt: Date;
+    skillHighlights: string[];
+    technologyHighlights: string[];
+}
+
+interface PdfLine {
+    text: string;
+    fontSize: number;
+    indent?: number;
+}
+
+const pdfPageWidth = 612;
+const pdfPageHeight = 792;
+const pdfMargin = 54;
+const pdfBottomMargin = 54;
+
+function sanitizePdfText(value: string) {
+    return value
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/\u2013|\u2014/g, '-')
+        .replace(/\u2018|\u2019/g, "'")
+        .replace(/\u201c|\u201d/g, '"')
+        .replace(/\u2022/g, '*')
+        .replace(/\u2026/g, '...')
+        .replace(/\u00a0/g, ' ')
+        .replace(/[^\x20-\x7E]/g, '?');
+}
+
+function escapePdfText(value: string) {
+    return value
+        .replace(/\\/g, '\\\\')
+        .replace(/\(/g, '\\(')
+        .replace(/\)/g, '\\)');
+}
+
+function wrapPdfText(text: string, fontSize: number, indent = 0) {
+    const availableWidth = pdfPageWidth - (pdfMargin * 2) - indent;
+    const approximateCharacterWidth = Math.max(4, fontSize * 0.52);
+    const maxCharacters = Math.max(18, Math.floor(availableWidth / approximateCharacterWidth));
+    const sanitized = sanitizePdfText(text).trim();
+
+    if (!sanitized) {
+        return [''];
+    }
+
+    const words = sanitized.split(/\s+/);
+    const lines: string[] = [];
+    let currentLine = '';
+
+    for (const word of words) {
+        const nextLine = currentLine ? `${currentLine} ${word}` : word;
+        if (nextLine.length <= maxCharacters) {
+            currentLine = nextLine;
+            continue;
+        }
+
+        if (currentLine) {
+            lines.push(currentLine);
+        }
+
+        if (word.length <= maxCharacters) {
+            currentLine = word;
+            continue;
+        }
+
+        let remainingWord = word;
+        while (remainingWord.length > maxCharacters) {
+            lines.push(remainingWord.slice(0, maxCharacters - 1));
+            remainingWord = remainingWord.slice(maxCharacters - 1);
+        }
+        currentLine = remainingWord;
+    }
+
+    if (currentLine) {
+        lines.push(currentLine);
+    }
+
+    return lines;
+}
+
+function pushWrappedLine(lines: PdfLine[], text: string, fontSize: number, indent = 0) {
+    wrapPdfText(text, fontSize, indent).forEach(line => {
+        lines.push({
+            text: line,
+            fontSize,
+            indent
+        });
+    });
+}
+
+function pushBlankLine(lines: PdfLine[], fontSize = 10) {
+    lines.push({
+        text: '',
+        fontSize
+    });
+}
+
+function formatGeneratedDate(value: Date) {
+    return value.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+    });
+}
+
+function getContactHref(method: PortfolioContactMethod) {
+    if (method.href?.trim()) {
+        return method.href.trim();
+    }
+
+    if (method.value.includes('@')) {
+        return `mailto:${method.value}`;
+    }
+
+    if (method.value.startsWith('http://') || method.value.startsWith('https://')) {
+        return method.value;
+    }
+
+    return null;
+}
+
+function formatEmployerLocation(employer: Employer) {
+    const parts = [employer.city?.trim(), employer.region?.trim(), employer.country?.trim()].filter(
+        (part): part is string => Boolean(part && part.length > 0)
+    );
+
+    return parts.join(', ');
+}
+
+function formatRoleDate(startDate: string, endDate?: string | null) {
+    const start = new Date(`${startDate}T12:00:00`);
+    const end = endDate ? new Date(`${endDate}T12:00:00`) : null;
+    const formatter = new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        year: 'numeric'
+    });
+
+    return `${formatter.format(start)} to ${end ? formatter.format(end) : 'Present'}`;
+}
+
+function summarizeRoleCopy(markdown: string) {
+    return sanitizePdfText(
+        markdown
+            .replace(/^#+\s*/gm, '')
+            .split(/\r?\n\r?\n/)
+            .map(paragraph => paragraph.trim())
+            .find(paragraph => paragraph.length > 0) ?? ''
+    );
+}
+
+function formatLinkLine(method: PortfolioContactMethod) {
+    const href = getContactHref(method);
+    const parts = [`${method.label}: ${method.value}`];
+    if (href && href !== method.value) {
+        parts.push(`(${href})`);
+    }
+
+    if (method.note?.trim()) {
+        parts.push(`- ${method.note.trim()}`);
+    }
+
+    return parts.join(' ');
+}
+
+function formatSocialLine(link: PortfolioSocialLink) {
+    const parts = [`${link.label}: ${link.handle?.trim() || link.url}`];
+    if (link.handle?.trim()) {
+        parts.push(`(${link.url})`);
+    }
+
+    if (link.summary?.trim()) {
+        parts.push(`- ${link.summary.trim()}`);
+    }
+
+    return parts.join(' ');
+}
+
+function buildPdfLines(options: ResumePdfExportOptions) {
+    const lines: PdfLine[] = [];
+    const displayName = options.profile?.displayName?.trim() || 'Portfolio Resume';
+    const headline = options.profile?.contactHeadline?.trim();
+    const availability = options.profile?.availabilityHeadline?.trim();
+    const summaryParts = [options.profile?.contactIntro?.trim(), options.profile?.availabilitySummary?.trim()].filter(
+        (part): part is string => Boolean(part && part.length > 0)
+    );
+
+    pushWrappedLine(lines, displayName, 18);
+    if (headline) {
+        pushWrappedLine(lines, headline, 12);
+    }
+    if (availability) {
+        pushWrappedLine(lines, availability, 10);
+    }
+    pushWrappedLine(lines, `Generated ${formatGeneratedDate(options.generatedAt)}`, 9);
+    pushBlankLine(lines, 10);
+
+    pushWrappedLine(lines, 'Current Resume View', 13);
+    pushWrappedLine(lines, `Time Window: ${options.activeTimeWindowLabel}`, 10);
+    pushWrappedLine(lines, `Employer Limit: ${options.activeEmployerLimitLabel}`, 10);
+    pushWrappedLine(lines, options.viewSummary, 10);
+    pushBlankLine(lines, 10);
+
+    if (options.profile) {
+        const contactMethods = options.profile.contactMethods.slice(0, 6);
+        const socialLinks = options.profile.socialLinks.slice(0, 4);
+
+        if (contactMethods.length > 0 || socialLinks.length > 0) {
+            pushWrappedLine(lines, 'Contact', 13);
+            contactMethods.forEach(method => pushWrappedLine(lines, formatLinkLine(method), 10, 14));
+            socialLinks.forEach(link => pushWrappedLine(lines, formatSocialLine(link), 10, 14));
+            pushBlankLine(lines, 10);
+        }
+    }
+
+    if (summaryParts.length > 0) {
+        pushWrappedLine(lines, 'Summary', 13);
+        summaryParts.forEach(paragraph => pushWrappedLine(lines, paragraph, 10));
+        pushBlankLine(lines, 10);
+    }
+
+    if (options.skillHighlights.length > 0 || options.technologyHighlights.length > 0) {
+        pushWrappedLine(lines, 'Highlighted Skills', 13);
+        if (options.skillHighlights.length > 0) {
+            pushWrappedLine(lines, `Skills: ${options.skillHighlights.join(', ')}`, 10);
+        }
+        if (options.technologyHighlights.length > 0) {
+            pushWrappedLine(lines, `Technologies: ${options.technologyHighlights.join(', ')}`, 10);
+        }
+        pushBlankLine(lines, 10);
+    }
+
+    pushWrappedLine(lines, 'Experience', 13);
+    if (options.employers.length === 0) {
+        pushWrappedLine(lines, 'No published work history matches the current resume filters.', 10);
+        return lines;
+    }
+
+    options.employers.forEach(employer => {
+        const location = formatEmployerLocation(employer);
+        pushWrappedLine(lines, employer.name, 12);
+        if (location) {
+            pushWrappedLine(lines, location, 10, 14);
+        }
+
+        employer.jobRoles.forEach(role => {
+            pushWrappedLine(lines, `${role.role} | ${formatRoleDate(role.startDate, role.endDate)}`, 10, 14);
+            const summary = summarizeRoleCopy(role.descriptionMarkdown);
+            if (summary) {
+                pushWrappedLine(lines, summary, 10, 28);
+            }
+
+            if (role.skills.length > 0) {
+                pushWrappedLine(lines, `Skills: ${role.skills.join(', ')}`, 9, 28);
+            }
+
+            if (role.technologies.length > 0) {
+                pushWrappedLine(lines, `Technologies: ${role.technologies.join(', ')}`, 9, 28);
+            }
+        });
+
+        pushBlankLine(lines, 10);
+    });
+
+    return lines;
+}
+
+export function buildResumePdfBytes(options: ResumePdfExportOptions) {
+    const lines = buildPdfLines(options);
+    const pages: string[][] = [[]];
+    let currentPageIndex = 0;
+    let currentY = pdfPageHeight - pdfMargin;
+
+    for (const line of lines) {
+        const lineHeight = line.text ? line.fontSize + 6 : line.fontSize;
+        if (currentY - lineHeight < pdfBottomMargin) {
+            pages.push([]);
+            currentPageIndex += 1;
+            currentY = pdfPageHeight - pdfMargin;
+        }
+
+        if (line.text) {
+            const x = pdfMargin + (line.indent ?? 0);
+            const escapedText = escapePdfText(line.text);
+            pages[currentPageIndex].push(`BT /F1 ${line.fontSize} Tf 1 0 0 1 ${x} ${currentY} Tm (${escapedText}) Tj ET`);
+        }
+
+        currentY -= lineHeight;
+    }
+
+    const objects: string[] = [];
+    const pageObjectNumbers: number[] = [];
+    const contentObjectNumbers: number[] = [];
+    const fontObjectNumber = 3;
+
+    objects[1] = '<< /Type /Catalog /Pages 2 0 R >>';
+    objects[2] = '';
+    objects[fontObjectNumber] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+
+    let nextObjectNumber = 4;
+    pages.forEach(pageCommands => {
+        const pageObjectNumber = nextObjectNumber++;
+        const contentObjectNumber = nextObjectNumber++;
+        pageObjectNumbers.push(pageObjectNumber);
+        contentObjectNumbers.push(contentObjectNumber);
+
+        const stream = pageCommands.join('\n');
+        objects[pageObjectNumber] = `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${pdfPageWidth} ${pdfPageHeight}] /Resources << /Font << /F1 ${fontObjectNumber} 0 R >> >> /Contents ${contentObjectNumber} 0 R >>`;
+        objects[contentObjectNumber] = `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`;
+    });
+
+    objects[2] = `<< /Type /Pages /Kids [${pageObjectNumbers.map(number => `${number} 0 R`).join(' ')}] /Count ${pageObjectNumbers.length} >>`;
+
+    const parts: string[] = ['%PDF-1.4'];
+    const offsets: number[] = [0];
+
+    for (let objectNumber = 1; objectNumber < objects.length; objectNumber += 1) {
+        offsets[objectNumber] = parts.join('\n').length + 1;
+        parts.push(`${objectNumber} 0 obj\n${objects[objectNumber]}\nendobj`);
+    }
+
+    const xrefOffset = parts.join('\n').length + 1;
+    const xrefEntries = ['0000000000 65535 f '];
+
+    for (let objectNumber = 1; objectNumber < objects.length; objectNumber += 1) {
+        xrefEntries.push(`${offsets[objectNumber].toString().padStart(10, '0')} 00000 n `);
+    }
+
+    parts.push(`xref\n0 ${objects.length}\n${xrefEntries.join('\n')}`);
+    parts.push(`trailer\n<< /Size ${objects.length} /Root 1 0 R >>`);
+    parts.push(`startxref\n${xrefOffset}`);
+    parts.push('%%EOF');
+
+    return new TextEncoder().encode(parts.join('\n'));
+}
+
+function buildDownloadFileName(displayName: string, timeWindowLabel: string, employerLimitLabel: string) {
+    const normalizedName = sanitizePdfText(displayName)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        || 'resume';
+    const normalizedTimeWindow = sanitizePdfText(timeWindowLabel)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    const normalizedEmployerLimit = sanitizePdfText(employerLimitLabel)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    return [normalizedName, normalizedTimeWindow, normalizedEmployerLimit, 'resume.pdf']
+        .filter(Boolean)
+        .join('-');
+}
+
+export function downloadResumePdf(options: ResumePdfExportOptions) {
+    if (typeof document === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+        throw new Error('This browser does not support PDF downloads.');
+    }
+
+    const bytes = buildResumePdfBytes(options);
+    const blob = new Blob([bytes], {
+        type: 'application/pdf'
+    });
+    const downloadUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const displayName = options.profile?.displayName?.trim() || 'resume';
+
+    link.href = downloadUrl;
+    link.download = buildDownloadFileName(displayName, options.activeTimeWindowLabel, options.activeEmployerLimitLabel);
+    link.rel = 'noreferrer';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(downloadUrl);
+}

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/resumePdf.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/resumePdf.ts
@@ -1,3 +1,6 @@
+import fontkit from '@pdf-lib/fontkit';
+import { PDFDocument } from 'pdf-lib';
+import unicodeFontUrl from '@fontpkg/unifont/unifont-15.0.01.ttf?url';
 import type { Employer, PortfolioContactMethod, PortfolioProfile, PortfolioSocialLink } from '../../app/types';
 
 export interface ResumePdfExportOptions {
@@ -22,31 +25,47 @@ const pdfPageHeight = 792;
 const pdfMargin = 54;
 const pdfBottomMargin = 54;
 
-function sanitizePdfText(value: string) {
+let unicodePdfFontBytesPromise: Promise<Uint8Array> | null = null;
+
+function normalizePdfText(value: string) {
     return value
-        .normalize('NFKD')
-        .replace(/[\u0300-\u036f]/g, '')
+        .normalize('NFC')
         .replace(/\u2013|\u2014/g, '-')
         .replace(/\u2018|\u2019/g, "'")
         .replace(/\u201c|\u201d/g, '"')
         .replace(/\u2022/g, '*')
         .replace(/\u2026/g, '...')
-        .replace(/\u00a0/g, ' ')
-        .replace(/[^\x20-\x7E]/g, '?');
+        .replace(/\u00a0/g, ' ');
 }
 
-function escapePdfText(value: string) {
-    return value
-        .replace(/\\/g, '\\\\')
-        .replace(/\(/g, '\\(')
-        .replace(/\)/g, '\\)');
+function sanitizePdfFileNamePart(value: string) {
+    return normalizePdfText(value)
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^\x20-\x7E]/g, '')
+        .trim();
+}
+
+function getPdfTextLength(value: string) {
+    return Array.from(value).length;
+}
+
+function splitPdfWord(value: string, maxCharacters: number) {
+    const codePoints = Array.from(value);
+    const segments: string[] = [];
+
+    for (let index = 0; index < codePoints.length; index += maxCharacters) {
+        segments.push(codePoints.slice(index, index + maxCharacters).join(''));
+    }
+
+    return segments;
 }
 
 function wrapPdfText(text: string, fontSize: number, indent = 0) {
     const availableWidth = pdfPageWidth - (pdfMargin * 2) - indent;
     const approximateCharacterWidth = Math.max(4, fontSize * 0.52);
     const maxCharacters = Math.max(18, Math.floor(availableWidth / approximateCharacterWidth));
-    const sanitized = sanitizePdfText(text).trim();
+    const sanitized = normalizePdfText(text).trim();
 
     if (!sanitized) {
         return [''];
@@ -58,7 +77,7 @@ function wrapPdfText(text: string, fontSize: number, indent = 0) {
 
     for (const word of words) {
         const nextLine = currentLine ? `${currentLine} ${word}` : word;
-        if (nextLine.length <= maxCharacters) {
+        if (getPdfTextLength(nextLine) <= maxCharacters) {
             currentLine = nextLine;
             continue;
         }
@@ -67,17 +86,16 @@ function wrapPdfText(text: string, fontSize: number, indent = 0) {
             lines.push(currentLine);
         }
 
-        if (word.length <= maxCharacters) {
+        if (getPdfTextLength(word) <= maxCharacters) {
             currentLine = word;
             continue;
         }
 
-        let remainingWord = word;
-        while (remainingWord.length > maxCharacters) {
-            lines.push(remainingWord.slice(0, maxCharacters - 1));
-            remainingWord = remainingWord.slice(maxCharacters - 1);
+        const segments = splitPdfWord(word, maxCharacters);
+        while (segments.length > 1) {
+            lines.push(segments.shift() ?? '');
         }
-        currentLine = remainingWord;
+        currentLine = segments[0] ?? '';
     }
 
     if (currentLine) {
@@ -148,7 +166,7 @@ function formatRoleDate(startDate: string, endDate?: string | null) {
 }
 
 function summarizeRoleCopy(markdown: string) {
-    return sanitizePdfText(
+    return normalizePdfText(
         markdown
             .replace(/^#+\s*/gm, '')
             .split(/\r?\n\r?\n/)
@@ -273,86 +291,76 @@ function buildPdfLines(options: ResumePdfExportOptions) {
     return lines;
 }
 
-export function buildResumePdfBytes(options: ResumePdfExportOptions) {
+export function buildResumePdfTextLines(options: ResumePdfExportOptions) {
+    return buildPdfLines(options)
+        .map(line => line.text)
+        .filter(text => text.length > 0);
+}
+
+async function loadUnicodePdfFontBytes() {
+    if (!unicodePdfFontBytesPromise) {
+        unicodePdfFontBytesPromise = fetch(unicodeFontUrl)
+            .then(async response => {
+                if (!response.ok) {
+                    throw new Error('Unable to load the PDF export font.');
+                }
+
+                return new Uint8Array(await response.arrayBuffer());
+            })
+            .catch(error => {
+                unicodePdfFontBytesPromise = null;
+                throw error;
+            });
+    }
+
+    return unicodePdfFontBytesPromise;
+}
+
+export async function buildResumePdfBytes(options: ResumePdfExportOptions) {
     const lines = buildPdfLines(options);
-    const pages: string[][] = [[]];
-    let currentPageIndex = 0;
+    const pdfDocument = await PDFDocument.create();
+    pdfDocument.registerFontkit(fontkit);
+    const font = await pdfDocument.embedFont(await loadUnicodePdfFontBytes(), {
+        subset: true
+    });
+    let page = pdfDocument.addPage([pdfPageWidth, pdfPageHeight]);
     let currentY = pdfPageHeight - pdfMargin;
 
     for (const line of lines) {
         const lineHeight = line.text ? line.fontSize + 6 : line.fontSize;
         if (currentY - lineHeight < pdfBottomMargin) {
-            pages.push([]);
-            currentPageIndex += 1;
+            page = pdfDocument.addPage([pdfPageWidth, pdfPageHeight]);
             currentY = pdfPageHeight - pdfMargin;
         }
 
         if (line.text) {
-            const x = pdfMargin + (line.indent ?? 0);
-            const escapedText = escapePdfText(line.text);
-            pages[currentPageIndex].push(`BT /F1 ${line.fontSize} Tf 1 0 0 1 ${x} ${currentY} Tm (${escapedText}) Tj ET`);
+            page.drawText(line.text, {
+                font,
+                size: line.fontSize,
+                x: pdfMargin + (line.indent ?? 0),
+                y: currentY
+            });
         }
 
         currentY -= lineHeight;
     }
 
-    const objects: string[] = [];
-    const pageObjectNumbers: number[] = [];
-    const contentObjectNumbers: number[] = [];
-    const fontObjectNumber = 3;
-
-    objects[1] = '<< /Type /Catalog /Pages 2 0 R >>';
-    objects[2] = '';
-    objects[fontObjectNumber] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
-
-    let nextObjectNumber = 4;
-    pages.forEach(pageCommands => {
-        const pageObjectNumber = nextObjectNumber++;
-        const contentObjectNumber = nextObjectNumber++;
-        pageObjectNumbers.push(pageObjectNumber);
-        contentObjectNumbers.push(contentObjectNumber);
-
-        const stream = pageCommands.join('\n');
-        objects[pageObjectNumber] = `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${pdfPageWidth} ${pdfPageHeight}] /Resources << /Font << /F1 ${fontObjectNumber} 0 R >> >> /Contents ${contentObjectNumber} 0 R >>`;
-        objects[contentObjectNumber] = `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`;
+    return pdfDocument.save({
+        useObjectStreams: false
     });
-
-    objects[2] = `<< /Type /Pages /Kids [${pageObjectNumbers.map(number => `${number} 0 R`).join(' ')}] /Count ${pageObjectNumbers.length} >>`;
-
-    const parts: string[] = ['%PDF-1.4'];
-    const offsets: number[] = [0];
-
-    for (let objectNumber = 1; objectNumber < objects.length; objectNumber += 1) {
-        offsets[objectNumber] = parts.join('\n').length + 1;
-        parts.push(`${objectNumber} 0 obj\n${objects[objectNumber]}\nendobj`);
-    }
-
-    const xrefOffset = parts.join('\n').length + 1;
-    const xrefEntries = ['0000000000 65535 f '];
-
-    for (let objectNumber = 1; objectNumber < objects.length; objectNumber += 1) {
-        xrefEntries.push(`${offsets[objectNumber].toString().padStart(10, '0')} 00000 n `);
-    }
-
-    parts.push(`xref\n0 ${objects.length}\n${xrefEntries.join('\n')}`);
-    parts.push(`trailer\n<< /Size ${objects.length} /Root 1 0 R >>`);
-    parts.push(`startxref\n${xrefOffset}`);
-    parts.push('%%EOF');
-
-    return new TextEncoder().encode(parts.join('\n'));
 }
 
 function buildDownloadFileName(displayName: string, timeWindowLabel: string, employerLimitLabel: string) {
-    const normalizedName = sanitizePdfText(displayName)
+    const normalizedName = sanitizePdfFileNamePart(displayName)
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '')
         || 'resume';
-    const normalizedTimeWindow = sanitizePdfText(timeWindowLabel)
+    const normalizedTimeWindow = sanitizePdfFileNamePart(timeWindowLabel)
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '');
-    const normalizedEmployerLimit = sanitizePdfText(employerLimitLabel)
+    const normalizedEmployerLimit = sanitizePdfFileNamePart(employerLimitLabel)
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '');
@@ -362,13 +370,19 @@ function buildDownloadFileName(displayName: string, timeWindowLabel: string, emp
         .join('-');
 }
 
-export function downloadResumePdf(options: ResumePdfExportOptions) {
-    if (typeof document === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+export async function downloadResumePdf(options: ResumePdfExportOptions) {
+    if (typeof document === 'undefined'
+        || typeof Blob === 'undefined'
+        || typeof URL === 'undefined'
+        || typeof URL.createObjectURL !== 'function'
+        || typeof fetch !== 'function') {
         throw new Error('This browser does not support PDF downloads.');
     }
 
-    const bytes = buildResumePdfBytes(options);
-    const blob = new Blob([bytes], {
+    const bytes = await buildResumePdfBytes(options);
+    const blobBytes = new Uint8Array(bytes.byteLength);
+    blobBytes.set(bytes);
+    const blob = new Blob([blobBytes], {
         type: 'application/pdf'
     });
     const downloadUrl = URL.createObjectURL(blob);

--- a/ProjectPortfolio2026/projectportfolio2026.client/vite.config.ts
+++ b/ProjectPortfolio2026/projectportfolio2026.client/vite.config.ts
@@ -14,6 +14,41 @@ export default defineConfig(({ command }) => {
 
     return {
         plugins: [plugin()],
+        build: {
+            // The Unicode PDF export engine is lazy-loaded, so a higher warning limit
+            // keeps build output focused on chunks that affect initial page load.
+            chunkSizeWarningLimit: 900,
+            rollupOptions: {
+                output: {
+                    manualChunks(id) {
+                        const normalizedId = id.replace(/\\/g, '/');
+
+                        if (normalizedId.includes('/node_modules/pdf-lib/')) {
+                            return 'pdf-lib';
+                        }
+
+                        if (normalizedId.includes('/node_modules/@pdf-lib/fontkit/')
+                            || normalizedId.includes('/node_modules/fontkit/')
+                            || normalizedId.includes('/node_modules/restructure/')) {
+                            return 'pdf-fontkit-core';
+                        }
+
+                        if (normalizedId.includes('/node_modules/unicode-properties/')
+                            || normalizedId.includes('/node_modules/unicode-trie/')
+                            || normalizedId.includes('/node_modules/dfa/')
+                            || normalizedId.includes('/node_modules/linebreak/')) {
+                            return 'pdf-fontkit-unicode';
+                        }
+
+                        if (normalizedId.includes('/node_modules/tiny-inflate/')
+                            || normalizedId.includes('/node_modules/brotli/')
+                            || normalizedId.includes('/node_modules/clone/')) {
+                            return 'pdf-fontkit-utils';
+                        }
+                    }
+                }
+            }
+        },
         resolve: {
             alias: {
                 '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
## Summary
- add a lightweight ATS-friendly PDF export pipeline for the public resume page
- wire the resume controls to export the active filtered resume view and surface clean download failures
- cover the export flow with focused client tests and update route expectations

## Verification
- npm test
- npm run lint
- npm run build
- dotnet build ProjectPortfolio2026.slnx -c Release

Closes #106