### PR TITLE
Support optional static resume link on resume page

### DIFF
--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.test.tsx
@@ -175,7 +175,6 @@ describe('ResumePage', () => {
 
         expect(screen.getByRole('heading', { name: 'Resume shell ready for public portfolio data.' })).toBeInTheDocument();
         expect(screen.getByText('Waiting for published resume data')).toBeInTheDocument();
-        expect(screen.getByText('Needs config')).toBeInTheDocument();
         expect(screen.getByText('Public contact and social links will appear here once the portfolio profile is configured.')).toBeInTheDocument();
         expect(screen.getByText('Published work history will appear here once employer and job-role records are available.')).toBeInTheDocument();
         expect(screen.queryByRole('heading', { name: 'Positioning for recruiters and hiring teams.' })).not.toBeInTheDocument();
@@ -188,6 +187,29 @@ describe('ResumePage', () => {
         expect(screen.getByRole('link', { name: 'Download Resume' })).toHaveAttribute('href', 'https://cdn.example.dev/resume.pdf');
         expect(screen.getByText('ATS-friendly PDF.')).toBeInTheDocument();
         expect(screen.getAllByText('Hosted file').length).toBeGreaterThan(0);
+    });
+
+    it('hides the resume source action when external configuration is incomplete', () => {
+        mockUseResumeConfiguration.mockReturnValue({
+            configuration: {
+                id: 1,
+                sourceType: 'none',
+                isConfigured: false,
+                sourceUrl: null,
+                displayLabel: null,
+                summary: null
+            },
+            isLoading: false,
+            error: null,
+            isMissing: true
+        });
+
+        render(<ResumePage />);
+
+        expect(screen.queryByRole('link', { name: 'Download Resume' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Open Resume Source/i })).not.toBeInTheDocument();
+        expect(screen.queryByText('Hosted file')).not.toBeInTheDocument();
+        expect(screen.queryByText('Needs config')).not.toBeInTheDocument();
     });
 
     it('renders structured summary, skill highlights, and full experience history', () => {

--- a/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
+++ b/ProjectPortfolio2026/projectportfolio2026.client/src/features/resume/ResumePage.tsx
@@ -302,7 +302,6 @@ export function ResumePage() {
         profile,
         isLoading: isProfileLoading,
         error: profileError,
-        isMissing: isProfileMissing
     } = usePortfolioProfile();
     const {
         employers,
@@ -313,7 +312,6 @@ export function ResumePage() {
         configuration: resumeConfiguration,
         isLoading: isResumeConfigurationLoading,
         error: resumeConfigurationError,
-        isMissing: isResumeConfigurationMissing
     } = useResumeConfiguration();
 
     const currentDate = new Date();
@@ -376,7 +374,9 @@ export function ResumePage() {
         filteredRoleCount,
         totalRoleCount
     );
-    const resumeSourceTypeLabel = resumeConfiguration?.sourceType === 'embed' ? 'Embed source' : 'Hosted file';
+    const hasStaticResumeSource = resumeConfiguration?.isConfigured === true
+        && Boolean(resumeConfiguration.sourceUrl?.trim())
+        && Boolean(resumeConfiguration.displayLabel?.trim());
 
     return (
         <main className="resume-page">
@@ -513,42 +513,28 @@ export function ResumePage() {
                                 <span className="coming-soon-pill">Coming Soon</span>
                             </button>
                         </div>
-                        <div className="resume-action-card">
-                            <div className="resume-action-copy">
-                                <span className="meta-label">Resume Source</span>
-                                <span className="resume-action-note">
-                                    {resumeConfiguration?.isConfigured
-                                        ? resumeSourceTypeLabel
-                                        : isResumeConfigurationMissing || isProfileMissing
-                                            ? 'Needs config'
-                                            : 'Unavailable'}
-                                </span>
-                            </div>
-                            {resumeConfiguration?.isConfigured && resumeConfiguration.sourceUrl && resumeConfiguration.displayLabel ? (
+                        {hasStaticResumeSource ? (
+                            <div className="resume-action-card">
+                                <div className="resume-action-copy">
+                                    <span className="meta-label">Resume Source</span>
+                                    <span className="resume-action-note">
+                                        {resumeConfiguration?.sourceType === 'embed' ? 'Embed source' : 'Hosted file'}
+                                    </span>
+                                </div>
                                 <a
                                     className="resume-action-button"
-                                    href={resumeConfiguration.sourceUrl}
+                                    href={resumeConfiguration?.sourceUrl ?? ''}
                                     target="_blank"
                                     rel="noreferrer"
-                                    aria-label={resumeConfiguration.displayLabel}>
-                                    <span>{resumeConfiguration.displayLabel}</span>
-                                    <span className="coming-soon-pill">{resumeSourceTypeLabel}</span>
+                                    aria-label={resumeConfiguration?.displayLabel ?? 'Open Resume Source'}>
+                                    <span>{resumeConfiguration?.displayLabel}</span>
+                                    <span className="coming-soon-pill">{resumeConfiguration?.sourceType === 'embed' ? 'Embed source' : 'Hosted file'}</span>
                                 </a>
-                            ) : (
-                                <button
-                                    className="resume-action-button"
-                                    type="button"
-                                    disabled
-                                    aria-disabled="true"
-                                    aria-label="Open Resume Source">
-                                    <span>Open Resume Source</span>
-                                    <span className="coming-soon-pill">Needs Config</span>
-                                </button>
-                            )}
-                            {resumeConfiguration?.isConfigured && resumeConfiguration.summary ? (
-                                <p>{resumeConfiguration.summary}</p>
-                            ) : null}
-                        </div>
+                                {resumeConfiguration?.summary ? (
+                                    <p>{resumeConfiguration.summary}</p>
+                                ) : null}
+                            </div>
+                        ) : null}
                     </div>
                 </article>
             </section>


### PR DESCRIPTION
## Summary`n- Hide the public resume source action unless resume configuration is complete.`n- Keep hosted/embedded source action available when URL and label are set.`n- Add tests to cover configured and missing configuration states.`n`n## Verification`n- npm run test -- --run src/features/resume/ResumePage.test.tsx`n- npm run build